### PR TITLE
ci(security): refine secret scanning and trivy config

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -48,8 +48,8 @@ jobs:
         continue-on-error: true
         with:
           path: ./
-          base: ${{ github.event.repository.default_branch }}
-          head: HEAD
+          base: ${{ github.event.pull_request.base.sha || github.event.before }}
+          head: ${{ github.event.pull_request.head.sha || github.event.after }}
           extra_args: --only-verified
 
       - name: Fail on verified secrets
@@ -71,6 +71,7 @@ jobs:
           scan-type: repo
           format: sarif
           output: trivy-results.sarif
+          trivyignores: .trivyignore.yaml
 
       - name: Upload Trivy results to GitHub Security tab
         if: always()
@@ -86,3 +87,4 @@ jobs:
           format: table
           severity: CRITICAL,HIGH
           exit-code: "1"
+          trivyignores: .trivyignore.yaml

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,7 @@
+vulnerabilities:
+  - id: CVE-2025-69872
+    statement: |
+      diskcache is a transitive dependency (fastmcp → py-key-value-aio[disk]).
+      nexus-mcp does not use DiskStore — only in-memory and Redis backends.
+      No patched version available. Exploitation requires local write access
+      to the cache directory, which is not exposed.


### PR DESCRIPTION
Update the security workflow to use more robust commit ranges for secret scanning across PRs and pushes. Add a .trivyignore file to suppress CVE-2025-69872, as it is a transitive dependency not utilized by the project's backends.