### PR TITLE
feat(server): add batch_prompt tool for parallel agent execution

### DIFF
--- a/src/nexus_mcp/server.py
+++ b/src/nexus_mcp/server.py
@@ -1,28 +1,120 @@
 # src/nexus_mcp/server.py
 """FastMCP server with CLI agent tools.
 
-Exposes two MCP tools:
-- prompt_agent: Send a prompt to a CLI agent (background task, returns immediately)
+Exposes three MCP tools:
+- batch_prompt: Send multiple prompts to CLI agents in parallel (primary tool)
+- prompt_agent: Send a prompt to a CLI agent (background task) — DEPRECATED, use batch_prompt
 - list_agents: Return list of supported agent names
 
-Background task design: prompt_agent uses @mcp.tool(task=True) so it runs
-asynchronously and returns a task ID immediately. This prevents MCP timeouts
-for long operations like YOLO mode (2-5 minutes).
+Background task design: both prompt_agent and batch_prompt use @mcp.tool(task=True) so they
+run asynchronously and return task IDs immediately. This prevents MCP timeouts for long
+operations like YOLO mode (2-5 minutes).
 
 Testability: The tool functions are defined as plain async functions and then
 registered with @mcp.tool so tests can import and call them directly without
 going through the FunctionTool wrapper.
 """
 
+import asyncio
 from typing import Any
 
 from fastmcp import FastMCP
 from fastmcp.dependencies import Progress
 
 from nexus_mcp.runners.factory import RunnerFactory
-from nexus_mcp.types import ExecutionMode, PromptRequest
+from nexus_mcp.types import (
+    DEFAULT_MAX_CONCURRENCY,
+    AgentTask,
+    AgentTaskResult,
+    ExecutionMode,
+    MultiPromptResponse,
+    PromptRequest,
+)
 
 mcp = FastMCP("nexus-mcp")
+
+
+def _assign_labels(tasks: list[AgentTask]) -> list[AgentTask]:
+    """Assign unique labels to tasks, preserving explicit ones.
+
+    Two-pass algorithm:
+    1. Reserve all explicit labels
+    2. Auto-assign from agent name with -N suffixes for collisions
+
+    Args:
+        tasks: List of AgentTask objects (may have label=None).
+
+    Returns:
+        New list of AgentTask objects with label set on every item.
+        Input tasks are never mutated (model_copy() used throughout).
+    """
+    reserved = {t.label for t in tasks if t.label is not None}
+
+    result: list[AgentTask] = []
+    for task in tasks:
+        if task.label is not None:
+            result.append(task)
+            continue
+
+        base = task.agent
+        if base not in reserved:
+            reserved.add(base)
+            result.append(task.model_copy(update={"label": base}))
+        else:
+            n = 2
+            while f"{base}-{n}" in reserved:
+                n += 1
+            label = f"{base}-{n}"
+            reserved.add(label)
+            result.append(task.model_copy(update={"label": label}))
+
+    return result
+
+
+async def batch_prompt(
+    tasks: list[AgentTask],
+    progress: Progress = Progress(),  # noqa: B008 -- FastMCP DI sentinel pattern
+    max_concurrency: int = DEFAULT_MAX_CONCURRENCY,
+) -> str:
+    """Send multiple prompts to CLI agents in parallel (primary tool).
+
+    Fans out tasks server-side with asyncio.gather and a semaphore, enabling
+    true parallel agent execution within a single MCP call. Single-task usage
+    is perfectly valid — batch_prompt replaces prompt_agent (now deprecated).
+
+    Args:
+        tasks: List of AgentTask objects, each with agent, prompt, and optional fields.
+        progress: Progress tracker (auto-injected by FastMCP).
+        max_concurrency: Max parallel agent invocations (default: 3).
+
+    Returns:
+        JSON string containing MultiPromptResponse with results for each task.
+    """
+    labelled = _assign_labels(tasks)
+    semaphore = asyncio.Semaphore(max_concurrency)
+
+    await progress.set_total(len(labelled))
+
+    async def _run_single(task: AgentTask) -> AgentTaskResult:
+        async with semaphore:
+            try:
+                request = PromptRequest(
+                    agent=task.agent,
+                    prompt=task.prompt,
+                    context=task.context,
+                    execution_mode=task.execution_mode,
+                    model=task.model,
+                )
+                runner = RunnerFactory.create(task.agent)
+                response = await runner.run(request)
+                await progress.increment(1)
+                return AgentTaskResult(label=task.label, output=response.output)  # type: ignore[arg-type]
+            except Exception as e:
+                await progress.increment(1)
+                return AgentTaskResult(label=task.label, error=str(e))  # type: ignore[arg-type]
+
+    results = await asyncio.gather(*[_run_single(t) for t in labelled])
+    return MultiPromptResponse(results=list(results)).model_dump_json()
 
 
 async def prompt_agent(
@@ -34,6 +126,11 @@ async def prompt_agent(
     model: str | None = None,
 ) -> str:
     """Send a prompt to a CLI agent as a background task.
+
+    .. deprecated::
+        Use ``batch_prompt`` instead. ``batch_prompt`` handles both single and
+        multi-task cases and is the primary tool going forward. ``prompt_agent``
+        remains functional for backward compatibility during the transition.
 
     Returns immediately with a task ID. Client polls for results.
     This prevents timeouts for long operations (YOLO mode: 2-5 minutes).
@@ -84,5 +181,6 @@ def list_agents() -> list[str]:
 
 # Register functions as MCP tools after definition so tests can import
 # and call the raw functions directly (not the FunctionTool wrappers).
+mcp.tool(task=True)(batch_prompt)
 mcp.tool(task=True)(prompt_agent)
 mcp.tool()(list_agents)

--- a/src/nexus_mcp/types.py
+++ b/src/nexus_mcp/types.py
@@ -1,8 +1,10 @@
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 type ExecutionMode = Literal["default", "sandbox", "yolo"]
+
+DEFAULT_MAX_CONCURRENCY = 3
 
 
 class PromptRequest(BaseModel):
@@ -46,3 +48,57 @@ class SubprocessResult(BaseModel):
     stdout: str
     stderr: str
     returncode: int
+
+
+class AgentTask(BaseModel):
+    """Per-task input for batch_prompt."""
+
+    agent: str
+    prompt: str
+    label: str | None = None
+    context: dict[str, Any] = Field(default_factory=dict)
+    execution_mode: ExecutionMode = "default"
+    model: str | None = None
+
+    @field_validator("agent", "prompt")
+    @classmethod
+    def must_not_be_empty(cls, v: str) -> str:
+        if not v:
+            raise ValueError("must not be empty")
+        return v
+
+
+class AgentTaskResult(BaseModel):
+    """Per-task output for batch_prompt — exactly one of output/error is set."""
+
+    label: str
+    output: str | None = None
+    error: str | None = None
+
+    @model_validator(mode="after")
+    def validate_xor(self) -> "AgentTaskResult":
+        if self.output is not None and self.error is not None:
+            raise ValueError("output and error are mutually exclusive")
+        if self.output is None and self.error is None:
+            raise ValueError("one of output or error must be set")
+        return self
+
+    @property
+    def success(self) -> bool:
+        return self.output is not None
+
+
+class MultiPromptResponse(BaseModel):
+    """Aggregate response from batch_prompt with auto-computed counts."""
+
+    results: list[AgentTaskResult]
+    total: int = 0
+    succeeded: int = 0
+    failed: int = 0
+
+    @model_validator(mode="after")
+    def compute_counts(self) -> "MultiPromptResponse":
+        self.total = len(self.results)
+        self.succeeded = sum(1 for r in self.results if r.success)
+        self.failed = self.total - self.succeeded
+        return self

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -3,7 +3,7 @@ import asyncio
 from typing import Any
 from unittest.mock import AsyncMock, Mock
 
-from nexus_mcp.types import AgentResponse, PromptRequest, SubprocessResult
+from nexus_mcp.types import AgentResponse, AgentTask, PromptRequest, SubprocessResult
 
 # ---------------------------------------------------------------------------
 # Reusable test constants
@@ -137,6 +137,19 @@ def make_agent_response(**overrides: Any) -> AgentResponse:
         "raw_output": GEMINI_JSON_RESPONSE,
     }
     return AgentResponse(**(defaults | overrides))
+
+
+def make_agent_task(**overrides: Any) -> AgentTask:
+    """Create an AgentTask with sensible defaults.
+
+    Usage::
+
+        task = make_agent_task()                              # defaults
+        task = make_agent_task(agent="codex")                 # override agent
+        task = make_agent_task(prompt="Do X", label="my-task")
+    """
+    defaults: dict[str, Any] = {"agent": "gemini", "prompt": "Hello"}
+    return AgentTask(**(defaults | overrides))
 
 
 def make_subprocess_result(**overrides: Any) -> SubprocessResult:

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -5,13 +5,16 @@ Mocking strategy: Mock at the RunnerFactory/runner boundary, NOT subprocess leve
 Server tests should be decoupled from runner internals.
 """
 
+import asyncio
+import json
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from nexus_mcp.exceptions import SubprocessError, UnsupportedAgentError
-from nexus_mcp.server import list_agents, prompt_agent
-from tests.fixtures import make_agent_response
+from nexus_mcp.server import _assign_labels, batch_prompt, list_agents, prompt_agent
+from nexus_mcp.types import DEFAULT_MAX_CONCURRENCY
+from tests.fixtures import make_agent_response, make_agent_task
 
 
 class TestPromptAgent:
@@ -142,3 +145,251 @@ class TestListAgents:
         """list_agents returns exactly the supported agent names."""
         agents = list_agents()
         assert agents == ["gemini"]
+
+
+class TestAssignLabels:
+    """Tests for the _assign_labels() pure helper."""
+
+    def test_single_task_gets_agent_name(self):
+        """A single unlabeled task gets its agent name as label."""
+        tasks = [make_agent_task(agent="gemini")]
+        result = _assign_labels(tasks)
+        assert result[0].label == "gemini"
+
+    def test_two_identical_agents_get_suffixes(self):
+        """Two tasks with the same agent get 'agent' and 'agent-2'."""
+        tasks = [make_agent_task(agent="gemini"), make_agent_task(agent="gemini")]
+        result = _assign_labels(tasks)
+        assert result[0].label == "gemini"
+        assert result[1].label == "gemini-2"
+
+    def test_three_identical_agents_get_suffixes(self):
+        """Three tasks with the same agent get 'agent', 'agent-2', 'agent-3'."""
+        tasks = [make_agent_task(agent="gemini") for _ in range(3)]
+        result = _assign_labels(tasks)
+        assert result[0].label == "gemini"
+        assert result[1].label == "gemini-2"
+        assert result[2].label == "gemini-3"
+
+    def test_explicit_label_preserved(self):
+        """An explicit label is kept as-is, not overwritten."""
+        tasks = [make_agent_task(agent="gemini", label="my-task")]
+        result = _assign_labels(tasks)
+        assert result[0].label == "my-task"
+
+    def test_explicit_label_blocks_auto_name(self):
+        """If 'gemini' is already an explicit label, auto-assigned gets 'gemini-2'."""
+        tasks = [
+            make_agent_task(agent="gemini", label="gemini"),
+            make_agent_task(agent="gemini"),
+        ]
+        result = _assign_labels(tasks)
+        assert result[0].label == "gemini"
+        assert result[1].label == "gemini-2"
+
+    def test_mixed_agents_no_suffix(self):
+        """Different agents don't get suffixes when there are no collisions."""
+        tasks = [make_agent_task(agent="gemini"), make_agent_task(agent="codex")]
+        result = _assign_labels(tasks)
+        assert result[0].label == "gemini"
+        assert result[1].label == "codex"
+
+    def test_returns_new_list_does_not_mutate(self):
+        """_assign_labels() returns a new list; input tasks are unchanged."""
+        tasks = [make_agent_task(agent="gemini")]
+        assert tasks[0].label is None
+        result = _assign_labels(tasks)
+        assert tasks[0].label is None  # original unchanged
+        assert result is not tasks
+        assert result[0] is not tasks[0]
+
+    def test_empty_list_returns_empty(self):
+        """An empty input list returns an empty list."""
+        assert _assign_labels([]) == []
+
+
+class TestBatchPrompt:
+    """Tests for the batch_prompt tool function."""
+
+    @patch("nexus_mcp.server.RunnerFactory")
+    async def test_all_success(self, mock_factory, progress):
+        """All tasks succeed → succeeded=2, failed=0."""
+        mock_runner = AsyncMock()
+        mock_runner.run.return_value = make_agent_response(output="ok")
+        mock_factory.create.return_value = mock_runner
+
+        tasks = [make_agent_task(), make_agent_task(prompt="Second")]
+        raw = await batch_prompt(tasks=tasks, progress=progress)
+        data = json.loads(raw)
+
+        assert data["succeeded"] == 2
+        assert data["failed"] == 0
+        assert data["total"] == 2
+
+    @patch("nexus_mcp.server.RunnerFactory")
+    async def test_partial_failure(self, mock_factory, progress):
+        """One task ok, one errors → succeeded=1, failed=1, good result preserved."""
+        mock_runner = AsyncMock()
+
+        async def run_side_effect(request):
+            if request.prompt == "ok":
+                return make_agent_response(output="good output")
+            raise RuntimeError("agent exploded")
+
+        mock_runner.run.side_effect = run_side_effect
+        mock_factory.create.return_value = mock_runner
+
+        tasks = [make_agent_task(prompt="ok"), make_agent_task(prompt="bad")]
+        raw = await batch_prompt(tasks=tasks, progress=progress)
+        data = json.loads(raw)
+
+        assert data["succeeded"] == 1
+        assert data["failed"] == 1
+        ok_result = next(r for r in data["results"] if r.get("output") == "good output")
+        assert ok_result is not None
+
+    @patch("nexus_mcp.server.RunnerFactory")
+    async def test_all_failures(self, mock_factory, progress):
+        """All tasks error → succeeded=0, failed=N."""
+        mock_runner = AsyncMock()
+        mock_runner.run.side_effect = RuntimeError("always fails")
+        mock_factory.create.return_value = mock_runner
+
+        tasks = [make_agent_task() for _ in range(3)]
+        raw = await batch_prompt(tasks=tasks, progress=progress)
+        data = json.loads(raw)
+
+        assert data["succeeded"] == 0
+        assert data["failed"] == 3
+
+    @patch("nexus_mcp.server.RunnerFactory")
+    async def test_concurrency_limit(self, mock_factory, progress):
+        """Max concurrent invocations does not exceed max_concurrency=2."""
+        max_concurrent = 0
+        current = 0
+
+        async def slow_run(request):
+            nonlocal max_concurrent, current
+            current += 1
+            max_concurrent = max(max_concurrent, current)
+            await asyncio.sleep(0)
+            current -= 1
+            return make_agent_response()
+
+        mock_runner = AsyncMock()
+        mock_runner.run.side_effect = slow_run
+        mock_factory.create.return_value = mock_runner
+
+        tasks = [make_agent_task() for _ in range(5)]
+        await batch_prompt(tasks=tasks, progress=progress, max_concurrency=2)
+
+        assert max_concurrent <= 2
+
+    @patch("nexus_mcp.server.RunnerFactory")
+    async def test_progress_called_per_task(self, mock_factory, progress):
+        """progress.increment() is called exactly once per task."""
+        mock_runner = AsyncMock()
+        mock_runner.run.return_value = make_agent_response()
+        mock_factory.create.return_value = mock_runner
+
+        tasks = [make_agent_task() for _ in range(4)]
+        await batch_prompt(tasks=tasks, progress=progress)
+
+        assert progress.increment.call_count == 4
+
+    @patch("nexus_mcp.server.RunnerFactory")
+    async def test_result_order_matches_input(self, mock_factory, progress):
+        """Results are in the same order as the input tasks."""
+        call_order: list[str] = []
+
+        async def ordered_run(request):
+            call_order.append(request.prompt)
+            return make_agent_response(output=f"result-{request.prompt}")
+
+        mock_runner = AsyncMock()
+        mock_runner.run.side_effect = ordered_run
+        mock_factory.create.return_value = mock_runner
+
+        tasks = [make_agent_task(prompt=f"p{i}") for i in range(3)]
+        raw = await batch_prompt(tasks=tasks, progress=progress)
+        data = json.loads(raw)
+
+        outputs = [r["output"] for r in data["results"]]
+        assert outputs == ["result-p0", "result-p1", "result-p2"]
+
+    @patch("nexus_mcp.server.RunnerFactory")
+    async def test_returns_json_string(self, mock_factory, progress):
+        """Output is a valid JSON string with a 'results' key."""
+        mock_runner = AsyncMock()
+        mock_runner.run.return_value = make_agent_response()
+        mock_factory.create.return_value = mock_runner
+
+        raw = await batch_prompt(tasks=[make_agent_task()], progress=progress)
+
+        assert isinstance(raw, str)
+        data = json.loads(raw)
+        assert "results" in data
+
+    @patch("nexus_mcp.server.RunnerFactory")
+    async def test_labels_auto_assigned(self, mock_factory, progress):
+        """Unlabeled tasks receive unique auto-assigned labels."""
+        mock_runner = AsyncMock()
+        mock_runner.run.return_value = make_agent_response()
+        mock_factory.create.return_value = mock_runner
+
+        tasks = [make_agent_task(agent="gemini"), make_agent_task(agent="gemini")]
+        raw = await batch_prompt(tasks=tasks, progress=progress)
+        data = json.loads(raw)
+
+        labels = [r["label"] for r in data["results"]]
+        assert len(set(labels)) == 2  # all unique
+
+    @patch("nexus_mcp.server.RunnerFactory")
+    async def test_empty_task_list(self, mock_factory, progress):
+        """An empty task list returns total=0 and empty results."""
+        raw = await batch_prompt(tasks=[], progress=progress)
+        data = json.loads(raw)
+
+        assert data["total"] == 0
+        assert data["results"] == []
+
+    @patch("nexus_mcp.server.RunnerFactory")
+    async def test_unexpected_exception_captured(self, mock_factory, progress):
+        """RuntimeError from runner is captured as task error, not propagated."""
+        mock_runner = AsyncMock()
+        mock_runner.run.side_effect = RuntimeError("unexpected boom")
+        mock_factory.create.return_value = mock_runner
+
+        raw = await batch_prompt(tasks=[make_agent_task()], progress=progress)
+        data = json.loads(raw)
+
+        assert data["failed"] == 1
+        assert "unexpected boom" in data["results"][0]["error"]
+
+    def test_default_concurrency_is_three(self):
+        """DEFAULT_MAX_CONCURRENCY constant equals 3."""
+        assert DEFAULT_MAX_CONCURRENCY == 3
+
+    @patch("nexus_mcp.server.RunnerFactory")
+    async def test_progress_set_total_called_once(self, mock_factory, progress):
+        """progress.set_total() is called exactly once with the task count."""
+        mock_runner = AsyncMock()
+        mock_runner.run.return_value = make_agent_response()
+        mock_factory.create.return_value = mock_runner
+
+        tasks = [make_agent_task() for _ in range(3)]
+        await batch_prompt(tasks=tasks, progress=progress)
+
+        progress.set_total.assert_called_once_with(3)
+
+    @patch("nexus_mcp.server.RunnerFactory")
+    async def test_single_task_no_suffix(self, mock_factory, progress):
+        """A single task's label is the agent name without any suffix."""
+        mock_runner = AsyncMock()
+        mock_runner.run.return_value = make_agent_response()
+        mock_factory.create.return_value = mock_runner
+
+        raw = await batch_prompt(tasks=[make_agent_task(agent="gemini")], progress=progress)
+        data = json.loads(raw)
+
+        assert data["results"][0]["label"] == "gemini"


### PR DESCRIPTION
Introduce the `batch_prompt` tool to support concurrent execution of multiple agent tasks within a single MCP call. This tool uses a semaphore-controlled fan-out pattern to manage parallel processing while preventing resource exhaustion.

Key changes:
- Implement `batch_prompt` with support for server-side progress tracking
- Add `_assign_labels` helper for automatic task identification and collision resolution
- Define `AgentTask`, `AgentTaskResult`, and `MultiPromptResponse` types with Pydantic validation
- Deprecate `prompt_agent` in favor of the more flexible batch API
- Add comprehensive unit tests for batch logic, concurrency limits, and result ordering