### PR TITLE
refactor(server): use models and FastMCP Context

### DIFF
--- a/src/nexus_mcp/__main__.py
+++ b/src/nexus_mcp/__main__.py
@@ -8,4 +8,4 @@ Usage:
 from nexus_mcp.server import mcp
 
 if __name__ == "__main__":
-    mcp.run()
+    mcp.run(transport="stdio")

--- a/src/nexus_mcp/server.py
+++ b/src/nexus_mcp/server.py
@@ -18,7 +18,7 @@ going through the FunctionTool wrapper.
 import asyncio
 from typing import Any
 
-from fastmcp import FastMCP
+from fastmcp import Context, FastMCP
 from fastmcp.dependencies import Progress, ProgressLike
 
 from nexus_mcp.runners.factory import RunnerFactory
@@ -75,7 +75,8 @@ async def batch_prompt(
     tasks: list[AgentTask],
     progress: ProgressLike = Progress(),  # type: ignore[assignment]  # noqa: B008
     max_concurrency: int = DEFAULT_MAX_CONCURRENCY,
-) -> str:
+    ctx: Context | None = None,
+) -> MultiPromptResponse:
     """Send multiple prompts to CLI agents in parallel (primary tool).
 
     Fans out tasks server-side with asyncio.gather and a semaphore, enabling
@@ -86,15 +87,18 @@ async def batch_prompt(
         tasks: List of AgentTask objects, each with agent, prompt, and optional fields.
         progress: Progress tracker (auto-injected by FastMCP).
         max_concurrency: Max parallel agent invocations (default: 3).
+        ctx: MCP context (auto-injected by FastMCP). None when called directly in tests.
 
     Returns:
-        JSON string containing MultiPromptResponse with results for each task.
+        MultiPromptResponse with results for each task.
     """
 
     labelled = _assign_labels(tasks)
     semaphore = asyncio.Semaphore(max_concurrency)
 
     await progress.set_total(len(labelled))
+    if ctx:
+        await ctx.info(f"Starting batch of {len(labelled)} tasks (concurrency={max_concurrency})")
 
     async def _run_single(task: AgentTask) -> AgentTaskResult:
         async with semaphore:
@@ -115,7 +119,10 @@ async def batch_prompt(
                 return AgentTaskResult(label=task.label, error=str(e))  # type: ignore[arg-type]
 
     results = await asyncio.gather(*[_run_single(t) for t in labelled])
-    return MultiPromptResponse(results=list(results)).model_dump_json()
+    response = MultiPromptResponse(results=list(results))
+    if ctx:
+        await ctx.info(f"Batch complete: {response.succeeded}/{response.total} succeeded")
+    return response
 
 
 async def prompt(
@@ -125,6 +132,7 @@ async def prompt(
     context: dict[str, Any] | None = None,
     execution_mode: ExecutionMode = "default",
     model: str | None = None,
+    ctx: Context | None = None,
 ) -> str:
     """Send a prompt to a CLI agent as a background task.
 
@@ -138,6 +146,7 @@ async def prompt(
         context: Optional context metadata
         execution_mode: 'default' (safe), 'sandbox', or 'yolo'
         model: Optional model name (uses CLI default if not specified)
+        ctx: MCP context (auto-injected by FastMCP). None when called directly in tests.
 
     Returns:
         Agent's response text
@@ -149,8 +158,7 @@ async def prompt(
         execution_mode=execution_mode,
         model=model,
     )
-    raw = await batch_prompt(tasks=[task], progress=progress)
-    result = MultiPromptResponse.model_validate_json(raw)
+    result = await batch_prompt(tasks=[task], progress=progress, ctx=ctx)
     task_result = result.results[0]
     if task_result.error:
         raise RuntimeError(task_result.error)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ any additional imports.
 from unittest.mock import AsyncMock
 
 import pytest
+from fastmcp import Context
 from fastmcp.server.dependencies import InMemoryProgress
 
 
@@ -23,3 +24,14 @@ def progress() -> AsyncMock:
     methods raise AttributeError instead of silently succeeding.
     """
     return AsyncMock(spec=InMemoryProgress)
+
+
+@pytest.fixture
+def ctx() -> AsyncMock:
+    """Minimal mock for FastMCP Context DI sentinel.
+
+    Context is None-defaulted in server functions, so tests that don't need
+    it can omit it. This fixture provides a spec'd mock for tests that
+    verify ctx.info() logging behavior.
+    """
+    return AsyncMock(spec=Context)

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -6,14 +6,13 @@ Server tests should be decoupled from runner internals.
 """
 
 import asyncio
-import json
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from nexus_mcp.exceptions import SubprocessError, UnsupportedAgentError
 from nexus_mcp.server import _assign_labels, batch_prompt, list_agents, prompt
-from nexus_mcp.types import DEFAULT_MAX_CONCURRENCY
+from nexus_mcp.types import DEFAULT_MAX_CONCURRENCY, MultiPromptResponse
 from tests.fixtures import make_agent_response, make_agent_task
 
 
@@ -145,6 +144,21 @@ class TestPrompt:
                 progress=progress,
             )
 
+    @patch("nexus_mcp.server.RunnerFactory")
+    async def test_ctx_forwarded_to_batch_prompt(self, mock_factory, progress, ctx):
+        """ctx passed to prompt() is forwarded through to batch_prompt()."""
+        _setup_mock_runner(mock_factory, output="Done")
+
+        await prompt(
+            agent="gemini",
+            prompt="Test prompt",
+            progress=progress,
+            ctx=ctx,
+        )
+
+        # batch_prompt calls ctx.info() twice — once at start, once at completion
+        assert ctx.info.await_count == 2
+
 
 class TestListAgents:
     """Tests for the list_agents tool function."""
@@ -225,12 +239,11 @@ class TestBatchPrompt:
         _setup_mock_runner(mock_factory, output="ok")
 
         tasks = [make_agent_task(), make_agent_task(prompt="Second")]
-        raw = await batch_prompt(tasks=tasks, progress=progress)
-        data = json.loads(raw)
+        result = await batch_prompt(tasks=tasks, progress=progress)
 
-        assert data["succeeded"] == 2
-        assert data["failed"] == 0
-        assert data["total"] == 2
+        assert result.succeeded == 2
+        assert result.failed == 0
+        assert result.total == 2
 
     @patch("nexus_mcp.server.RunnerFactory")
     async def test_partial_failure(self, mock_factory, progress):
@@ -244,12 +257,11 @@ class TestBatchPrompt:
         _setup_mock_runner(mock_factory, side_effect=run_side_effect)
 
         tasks = [make_agent_task(prompt="ok"), make_agent_task(prompt="bad")]
-        raw = await batch_prompt(tasks=tasks, progress=progress)
-        data = json.loads(raw)
+        result = await batch_prompt(tasks=tasks, progress=progress)
 
-        assert data["succeeded"] == 1
-        assert data["failed"] == 1
-        ok_result = next(r for r in data["results"] if r.get("output") == "good output")
+        assert result.succeeded == 1
+        assert result.failed == 1
+        ok_result = next(r for r in result.results if r.output == "good output")
         assert ok_result is not None
 
     @patch("nexus_mcp.server.RunnerFactory")
@@ -258,11 +270,10 @@ class TestBatchPrompt:
         _setup_mock_runner(mock_factory, side_effect=RuntimeError("always fails"))
 
         tasks = [make_agent_task() for _ in range(3)]
-        raw = await batch_prompt(tasks=tasks, progress=progress)
-        data = json.loads(raw)
+        result = await batch_prompt(tasks=tasks, progress=progress)
 
-        assert data["succeeded"] == 0
-        assert data["failed"] == 3
+        assert result.succeeded == 0
+        assert result.failed == 3
 
     @patch("nexus_mcp.server.RunnerFactory")
     async def test_concurrency_limit(self, mock_factory, progress):
@@ -307,22 +318,20 @@ class TestBatchPrompt:
         _setup_mock_runner(mock_factory, side_effect=ordered_run)
 
         tasks = [make_agent_task(prompt=f"p{i}") for i in range(3)]
-        raw = await batch_prompt(tasks=tasks, progress=progress)
-        data = json.loads(raw)
+        result = await batch_prompt(tasks=tasks, progress=progress)
 
-        outputs = [r["output"] for r in data["results"]]
+        outputs = [r.output for r in result.results]
         assert outputs == ["result-p0", "result-p1", "result-p2"]
 
     @patch("nexus_mcp.server.RunnerFactory")
-    async def test_returns_json_string(self, mock_factory, progress):
-        """Output is a valid JSON string with a 'results' key."""
+    async def test_returns_multi_prompt_response(self, mock_factory, progress):
+        """Output is a MultiPromptResponse Pydantic model with a 'results' attribute."""
         _setup_mock_runner(mock_factory)
 
-        raw = await batch_prompt(tasks=[make_agent_task()], progress=progress)
+        result = await batch_prompt(tasks=[make_agent_task()], progress=progress)
 
-        assert isinstance(raw, str)
-        data = json.loads(raw)
-        assert "results" in data
+        assert isinstance(result, MultiPromptResponse)
+        assert hasattr(result, "results")
 
     @patch("nexus_mcp.server.RunnerFactory")
     async def test_labels_auto_assigned(self, mock_factory, progress):
@@ -330,31 +339,28 @@ class TestBatchPrompt:
         _setup_mock_runner(mock_factory)
 
         tasks = [make_agent_task(agent="gemini"), make_agent_task(agent="gemini")]
-        raw = await batch_prompt(tasks=tasks, progress=progress)
-        data = json.loads(raw)
+        result = await batch_prompt(tasks=tasks, progress=progress)
 
-        labels = [r["label"] for r in data["results"]]
+        labels = [r.label for r in result.results]
         assert len(set(labels)) == 2  # all unique
 
     @patch("nexus_mcp.server.RunnerFactory")
     async def test_empty_task_list(self, mock_factory, progress):
         """An empty task list returns total=0 and empty results."""
-        raw = await batch_prompt(tasks=[], progress=progress)
-        data = json.loads(raw)
+        result = await batch_prompt(tasks=[], progress=progress)
 
-        assert data["total"] == 0
-        assert data["results"] == []
+        assert result.total == 0
+        assert result.results == []
 
     @patch("nexus_mcp.server.RunnerFactory")
     async def test_unexpected_exception_captured(self, mock_factory, progress):
         """RuntimeError from runner is captured as task error, not propagated."""
         _setup_mock_runner(mock_factory, side_effect=RuntimeError("unexpected boom"))
 
-        raw = await batch_prompt(tasks=[make_agent_task()], progress=progress)
-        data = json.loads(raw)
+        result = await batch_prompt(tasks=[make_agent_task()], progress=progress)
 
-        assert data["failed"] == 1
-        assert "unexpected boom" in data["results"][0]["error"]
+        assert result.failed == 1
+        assert "unexpected boom" in result.results[0].error
 
     def test_default_concurrency_is_three(self):
         """DEFAULT_MAX_CONCURRENCY constant equals 3."""
@@ -375,7 +381,24 @@ class TestBatchPrompt:
         """A single task's label is the agent name without any suffix."""
         _setup_mock_runner(mock_factory)
 
-        raw = await batch_prompt(tasks=[make_agent_task(agent="gemini")], progress=progress)
-        data = json.loads(raw)
+        result = await batch_prompt(tasks=[make_agent_task(agent="gemini")], progress=progress)
 
-        assert data["results"][0]["label"] == "gemini"
+        assert result.results[0].label == "gemini"
+
+    @patch("nexus_mcp.server.RunnerFactory")
+    async def test_ctx_info_called_on_start_and_complete(self, mock_factory, progress, ctx):
+        """ctx.info() is awaited exactly twice: once at start, once at completion."""
+        _setup_mock_runner(mock_factory)
+
+        await batch_prompt(tasks=[make_agent_task()], progress=progress, ctx=ctx)
+
+        assert ctx.info.await_count == 2
+
+    @patch("nexus_mcp.server.RunnerFactory")
+    async def test_ctx_none_does_not_raise(self, mock_factory, progress):
+        """Default ctx=None completes without error (documents the None contract)."""
+        _setup_mock_runner(mock_factory)
+
+        # Should not raise even though ctx is None (the default)
+        result = await batch_prompt(tasks=[make_agent_task()], progress=progress)
+        assert isinstance(result, MultiPromptResponse)


### PR DESCRIPTION
Update batch_prompt and prompt to leverage FastMCP v3 features. batch_prompt now returns a MultiPromptResponse object instead of a JSON string, and both functions now support the injected Context for server-side logging.

- Inject FastMCP Context for progress and info logging
- Change batch_prompt return type to MultiPromptResponse
- Update main entry point to use stdio transport
- Update tests to reflect model-based returns and context usage