### PR TITLE
feat(runners): implement exponential backoff retry mechanism

### DIFF
--- a/src/nexus_mcp/config.py
+++ b/src/nexus_mcp/config.py
@@ -19,6 +19,14 @@ def _get_int_env(env_var: str, default: str, label: str) -> int:
         raise ConfigurationError(f"Invalid {label} value: {raw!r}", config_key=env_var) from None
 
 
+def _get_float_env(env_var: str, default: str, label: str) -> float:
+    raw = os.getenv(env_var, default)
+    try:
+        return float(raw)
+    except ValueError:
+        raise ConfigurationError(f"Invalid {label} value: {raw!r}", config_key=env_var) from None
+
+
 def get_global_output_limit() -> int:
     """Get maximum output size in bytes from env var.
 
@@ -47,6 +55,51 @@ def get_global_timeout() -> int:
         NEXUS_TIMEOUT_SECONDS: Subprocess timeout in seconds
     """
     return _get_int_env("NEXUS_TIMEOUT_SECONDS", "600", "timeout")
+
+
+def get_retry_max_attempts() -> int:
+    """Get maximum retry attempts from env var.
+
+    Returns:
+        Max retry attempts (default: 3)
+
+    Raises:
+        ConfigurationError: If env var value is not a valid integer
+
+    Environment Variable:
+        NEXUS_RETRY_MAX_ATTEMPTS: Max number of attempts (including the first)
+    """
+    return _get_int_env("NEXUS_RETRY_MAX_ATTEMPTS", "3", "retry max attempts")
+
+
+def get_retry_base_delay() -> float:
+    """Get retry base delay in seconds from env var.
+
+    Returns:
+        Base delay in seconds for exponential backoff (default: 2.0s)
+
+    Raises:
+        ConfigurationError: If env var value is not a valid float
+
+    Environment Variable:
+        NEXUS_RETRY_BASE_DELAY: Base seconds for exponential backoff
+    """
+    return _get_float_env("NEXUS_RETRY_BASE_DELAY", "2.0", "retry base delay")
+
+
+def get_retry_max_delay() -> float:
+    """Get retry max delay cap in seconds from env var.
+
+    Returns:
+        Maximum delay cap in seconds (default: 60.0s)
+
+    Raises:
+        ConfigurationError: If env var value is not a valid float
+
+    Environment Variable:
+        NEXUS_RETRY_MAX_DELAY: Maximum seconds to wait between retries
+    """
+    return _get_float_env("NEXUS_RETRY_MAX_DELAY", "60.0", "retry max delay")
 
 
 def get_agent_env(agent: str, key: str, default: str | None = None) -> str | None:

--- a/src/nexus_mcp/exceptions.py
+++ b/src/nexus_mcp/exceptions.py
@@ -142,6 +142,47 @@ class SubprocessTimeoutError(SubprocessError):
         self.timeout = timeout
 
 
+class RetryableError(SubprocessError):
+    """Transient subprocess error that should be retried.
+
+    Raised when a CLI subprocess returns an error code indicating a temporary
+    condition (e.g., rate limiting HTTP 429, service unavailability HTTP 503).
+    The retry loop in AbstractRunner will catch this and retry with backoff.
+
+    Attributes:
+        retry_after: Suggested wait time in seconds before retrying (None = no hint).
+        stderr: Inherited from SubprocessError.
+        command: Inherited from SubprocessError.
+        returncode: Inherited from SubprocessError.
+        stdout: Inherited from SubprocessError.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        retry_after: float | None = None,
+        stderr: str = "",
+        command: list[str] | None = None,
+        returncode: int | None = None,
+        stdout: str = "",
+    ):
+        """Initialize RetryableError.
+
+        Args:
+            message: Human-readable error description.
+            retry_after: Suggested seconds to wait before retrying (keyword-only, default: None).
+            stderr: Standard error output from the subprocess (default: "").
+            command: The command that failed (default: None).
+            returncode: The subprocess exit code (default: None).
+            stdout: Standard output from the subprocess (default: "").
+        """
+        super().__init__(
+            message, stderr=stderr, command=command, returncode=returncode, stdout=stdout
+        )
+        self.retry_after = retry_after
+
+
 class CLINotFoundError(NexusMCPError):
     """CLI binary not found in PATH.
 

--- a/src/nexus_mcp/runners/base.py
+++ b/src/nexus_mcp/runners/base.py
@@ -5,22 +5,38 @@ Defines:
 - CLIRunner: Protocol specifying the runner interface
 - AbstractRunner: ABC implementing Template Method pattern
 
-Template Method pattern in AbstractRunner.run():
+Template Method pattern in AbstractRunner._execute():
 1. build_command(request) → list[str]
 2. run_subprocess(command) → SubprocessResult
 3. Check returncode != 0 → raise SubprocessError (fail fast)
 4. parse_output(stdout, stderr) → AgentResponse
 5. _apply_output_limit(response) → AgentResponse (truncate if needed)
+
+AbstractRunner.run() wraps _execute() in a retry loop:
+- Retries on RetryableError with exponential backoff + full jitter
+- Non-retryable errors (SubprocessError, ParseError) propagate immediately
+- max_attempts from request.max_retries or NEXUS_RETRY_MAX_ATTEMPTS env var
 """
 
+import asyncio
+import logging
+import random
 import tempfile
 from abc import ABC, abstractmethod
 from typing import Protocol
 
-from nexus_mcp.config import get_global_output_limit, get_global_timeout
-from nexus_mcp.exceptions import SubprocessError
+from nexus_mcp.config import (
+    get_global_output_limit,
+    get_global_timeout,
+    get_retry_base_delay,
+    get_retry_max_attempts,
+    get_retry_max_delay,
+)
+from nexus_mcp.exceptions import RetryableError, SubprocessError
 from nexus_mcp.process import run_subprocess
 from nexus_mcp.types import AgentResponse, PromptRequest
+
+logger = logging.getLogger(__name__)
 
 
 class CLIRunner(Protocol):
@@ -64,9 +80,51 @@ class AbstractRunner(ABC):
     def __init__(self) -> None:
         """Initialize runner with global configuration."""
         self.timeout = get_global_timeout()
+        self.base_delay = get_retry_base_delay()
+        self.max_delay = get_retry_max_delay()
+        self.default_max_attempts = get_retry_max_attempts()
 
     async def run(self, request: PromptRequest) -> AgentResponse:
-        """Execute CLI agent using Template Method pattern.
+        """Execute CLI agent with retry on transient errors.
+
+        Wraps _execute() in a retry loop. RetryableError triggers exponential
+        backoff with full jitter. All other exceptions propagate immediately.
+
+        Args:
+            request: Prompt request with agent, prompt, execution mode, etc.
+                     request.max_retries overrides the env-var default when set.
+
+        Returns:
+            AgentResponse with parsed output and metadata.
+
+        Raises:
+            RetryableError: If all retry attempts are exhausted.
+            SubprocessError: If CLI fails with a non-retryable error code.
+            ParseError: If output parsing fails.
+        """
+        max_attempts = (
+            request.max_retries if request.max_retries is not None else self.default_max_attempts
+        )
+        for attempt in range(max_attempts):
+            try:
+                return await self._execute(request)
+            except RetryableError as e:
+                if attempt == max_attempts - 1:
+                    raise
+                delay = self._compute_backoff(attempt, e.retry_after)
+                logger.warning(
+                    "Retryable error (attempt %d/%d), retrying in %.1fs: %s",
+                    attempt + 1,
+                    max_attempts,
+                    delay,
+                    e,
+                )
+                await asyncio.sleep(delay)
+        # Unreachable: loop always returns or raises — satisfies type checker
+        raise AssertionError("unreachable: retry loop exited without result or exception")
+
+    async def _execute(self, request: PromptRequest) -> AgentResponse:
+        """Execute CLI agent once using Template Method pattern.
 
         Template steps:
         1. build_command(request) → command list
@@ -82,6 +140,7 @@ class AbstractRunner(ABC):
             AgentResponse with parsed output and metadata.
 
         Raises:
+            RetryableError: If _recover_from_error raises for a retryable error code.
             SubprocessError: If CLI fails (non-zero exit) or subprocess execution errors.
             ParseError: If output parsing fails (from parse_output()).
         """
@@ -111,6 +170,28 @@ class AbstractRunner(ABC):
 
         # Step 5: Apply output limiting
         return self._apply_output_limit(response)
+
+    def _compute_backoff(self, attempt: int, retry_after: float | None) -> float:
+        """Compute exponential backoff delay with full jitter.
+
+        Uses AWS-recommended full jitter formula:
+            delay = random.uniform(0, min(max_delay, base_delay * 2^attempt))
+
+        If retry_after hint is provided, uses max(computed, retry_after) to
+        respect the server's suggested wait time.
+
+        Args:
+            attempt: Zero-based attempt index (0 = first retry after first failure).
+            retry_after: Optional server-suggested wait time in seconds.
+
+        Returns:
+            Delay in seconds to wait before the next attempt.
+        """
+        cap = min(self.max_delay, self.base_delay * (2**attempt))
+        computed = random.uniform(0, cap)
+        if retry_after is not None:
+            return max(computed, retry_after)
+        return computed
 
     def _apply_output_limit(self, response: AgentResponse) -> AgentResponse:
         """Truncate output if exceeds limit, save full output to temp file.

--- a/src/nexus_mcp/runners/gemini.py
+++ b/src/nexus_mcp/runners/gemini.py
@@ -17,10 +17,12 @@ from typing import Any
 
 from nexus_mcp.cli_detector import detect_cli, get_cli_capabilities, get_cli_version
 from nexus_mcp.config import get_agent_env
-from nexus_mcp.exceptions import CLINotFoundError, ParseError, SubprocessError
+from nexus_mcp.exceptions import CLINotFoundError, ParseError, RetryableError, SubprocessError
 from nexus_mcp.parser import extract_last_json_array, extract_last_json_object
 from nexus_mcp.runners.base import AbstractRunner
 from nexus_mcp.types import AgentResponse, PromptRequest
+
+_RETRYABLE_CODES: frozenset[int] = frozenset({429, 503})
 
 
 class GeminiRunner(AbstractRunner):
@@ -209,8 +211,17 @@ class GeminiRunner(AbstractRunner):
         status = error.get("status", "")
         if code == 1 and message == "[object Object]":
             return
+        error_msg = f"Gemini API error {code}: {message} ({status})"
+        if isinstance(code, int) and code in _RETRYABLE_CODES:
+            raise RetryableError(
+                error_msg,
+                stderr=stderr,
+                stdout=stdout,
+                returncode=returncode,
+                command=command,
+            )
         raise SubprocessError(
-            f"Gemini API error {code}: {message} ({status})",
+            error_msg,
             stderr=stderr,
             stdout=stdout,
             returncode=returncode,

--- a/src/nexus_mcp/server.py
+++ b/src/nexus_mcp/server.py
@@ -109,6 +109,7 @@ async def batch_prompt(
                     context=task.context,
                     execution_mode=task.execution_mode,
                     model=task.model,
+                    max_retries=task.max_retries,
                 )
                 runner = RunnerFactory.create(task.agent)
                 response = await runner.run(request)
@@ -132,6 +133,7 @@ async def prompt(
     context: dict[str, Any] | None = None,
     execution_mode: ExecutionMode = "default",
     model: str | None = None,
+    max_retries: int | None = None,
     ctx: Context | None = None,
 ) -> str:
     """Send a prompt to a CLI agent as a background task.
@@ -146,6 +148,7 @@ async def prompt(
         context: Optional context metadata
         execution_mode: 'default' (safe), 'sandbox', or 'yolo'
         model: Optional model name (uses CLI default if not specified)
+        max_retries: Max retry attempts for transient errors (None uses env default)
         ctx: MCP context (auto-injected by FastMCP). None when called directly in tests.
 
     Returns:
@@ -157,6 +160,7 @@ async def prompt(
         context=context or {},
         execution_mode=execution_mode,
         model=model,
+        max_retries=max_retries,
     )
     result = await batch_prompt(tasks=[task], progress=progress, ctx=ctx)
     task_result = result.results[0]

--- a/src/nexus_mcp/types.py
+++ b/src/nexus_mcp/types.py
@@ -24,6 +24,10 @@ class PromptRequest(BaseModel):
         default_factory=list,
         description="Optional file paths for agent context (appended to prompt)",
     )
+    max_retries: int | None = Field(
+        default=None,
+        description="Max retry attempts for transient errors (None uses NEXUS_RETRY_MAX_ATTEMPTS)",
+    )
 
 
 class AgentResponse(BaseModel):
@@ -58,6 +62,7 @@ class AgentTask(BaseModel):
     context: dict[str, Any] = Field(default_factory=dict)
     execution_mode: ExecutionMode = "default"
     model: str | None = None
+    max_retries: int | None = None
 
     @field_validator("agent", "prompt")
     @classmethod

--- a/tests/unit/runners/conftest.py
+++ b/tests/unit/runners/conftest.py
@@ -17,3 +17,18 @@ def mock_cli_detection():
     """
     with cli_detection_mocks() as mock:
         yield mock
+
+
+@pytest.fixture(autouse=True)
+def fast_retry_sleep(monkeypatch):
+    """Patch asyncio.sleep to be instant for all runner unit tests.
+
+    Prevents real waiting during the retry backoff loop. Tests in
+    tests/unit/test_process.py (timeout tests) are unaffected since
+    they are outside this directory.
+    """
+
+    async def instant_sleep(_: float) -> None:
+        pass
+
+    monkeypatch.setattr("asyncio.sleep", instant_sleep)

--- a/tests/unit/runners/test_base.py
+++ b/tests/unit/runners/test_base.py
@@ -6,17 +6,18 @@ Tests verify:
 - AbstractRunner implements Template Method pattern
 - run() orchestrates: build_command → run_subprocess → parse_output
 - run() raises SubprocessError on non-zero return codes (fail fast)
+- run() retries on RetryableError with exponential backoff
 """
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from nexus_mcp.exceptions import SubprocessError
+from nexus_mcp.exceptions import ParseError, RetryableError, SubprocessError
 from nexus_mcp.process import run_subprocess
 from nexus_mcp.runners.base import AbstractRunner, CLIRunner
 from nexus_mcp.types import AgentResponse, PromptRequest
-from tests.fixtures import create_mock_process, make_prompt_request
+from tests.fixtures import create_mock_process, make_agent_response, make_prompt_request
 
 
 class ConcreteRunner(AbstractRunner):
@@ -213,3 +214,175 @@ class TestAbstractRunner:
             command=["test-cli"],
         )
         assert result is None
+
+
+class TestRetryLoop:
+    """Test AbstractRunner retry loop behavior (run() wraps _execute() with backoff)."""
+
+    @pytest.fixture
+    def runner(self) -> ConcreteRunner:
+        """Provide test runner instance."""
+        return ConcreteRunner()
+
+    @patch("nexus_mcp.process.asyncio.create_subprocess_exec")
+    async def test_no_retry_on_success(self, mock_exec, runner):
+        """Successful execution calls subprocess exactly once."""
+        mock_exec.return_value = create_mock_process(stdout="ok output")
+        request = make_prompt_request()
+
+        await runner.run(request)
+
+        assert mock_exec.await_count == 1
+
+    @patch("nexus_mcp.process.asyncio.create_subprocess_exec")
+    async def test_retries_on_retryable_error_and_succeeds(self, mock_exec, runner):
+        """Retries after RetryableError, returns AgentResponse on success attempt."""
+        # Fail twice with RetryableError, succeed on third attempt
+        mock_exec.side_effect = [
+            create_mock_process(stdout='{"error": {"code": 429}}', returncode=1),
+            create_mock_process(stdout='{"error": {"code": 429}}', returncode=1),
+            create_mock_process(stdout="success output", returncode=0),
+        ]
+
+        # ConcreteRunner has no _try_extract_error override, so returncode=1 raises
+        # plain SubprocessError (non-retryable) from _execute. We need a runner that
+        # raises RetryableError. Use _execute mock instead.
+        success_response = make_agent_response(output="success output")
+        retryable = RetryableError("rate limit", returncode=429)
+
+        runner._execute = AsyncMock(  # type: ignore[method-assign]
+            side_effect=[retryable, retryable, success_response]
+        )
+        request = make_prompt_request(max_retries=3)
+
+        response = await runner.run(request)
+
+        assert response.output == "success output"
+        assert runner._execute.await_count == 3
+
+    @patch("nexus_mcp.process.asyncio.create_subprocess_exec")
+    async def test_exhausts_attempts_reraises_retryable_error(self, mock_exec, runner):
+        """When all attempts fail with RetryableError, re-raises the last one."""
+        retryable = RetryableError("rate limit", returncode=429)
+        runner._execute = AsyncMock(side_effect=retryable)  # type: ignore[method-assign]
+        request = make_prompt_request(max_retries=3)
+
+        with pytest.raises(RetryableError) as exc_info:
+            await runner.run(request)
+
+        assert exc_info.value.returncode == 429
+        assert runner._execute.await_count == 3
+
+    @patch("nexus_mcp.process.asyncio.create_subprocess_exec")
+    async def test_no_retry_on_plain_subprocess_error(self, mock_exec, runner):
+        """Non-retryable SubprocessError propagates immediately without retry."""
+        runner._execute = AsyncMock(  # type: ignore[method-assign]
+            side_effect=SubprocessError("auth failed", returncode=401)
+        )
+        request = make_prompt_request(max_retries=3)
+
+        with pytest.raises(SubprocessError) as exc_info:
+            await runner.run(request)
+
+        # Only one attempt — no retry on SubprocessError
+        assert runner._execute.await_count == 1
+        assert exc_info.value.returncode == 401
+
+    @patch("nexus_mcp.process.asyncio.create_subprocess_exec")
+    async def test_no_retry_on_parse_error(self, mock_exec, runner):
+        """ParseError propagates immediately without retry."""
+        runner._execute = AsyncMock(  # type: ignore[method-assign]
+            side_effect=ParseError("bad json")
+        )
+        request = make_prompt_request(max_retries=3)
+
+        with pytest.raises(ParseError):
+            await runner.run(request)
+
+        assert runner._execute.await_count == 1
+
+    def test_compute_backoff_stays_within_max_delay(self, runner):
+        """Backoff delay never exceeds max_delay regardless of attempt number."""
+        runner.max_delay = 10.0
+        runner.base_delay = 2.0
+
+        # At high attempt numbers, cap = min(10, 2 * 2^100) → cap=10
+        for attempt in range(20):
+            delay = runner._compute_backoff(attempt, retry_after=None)
+            assert delay <= runner.max_delay
+
+    def test_compute_backoff_uses_full_jitter(self, runner):
+        """Backoff uses random.uniform(0, cap) — result is within [0, cap]."""
+        runner.base_delay = 2.0
+        runner.max_delay = 60.0
+
+        # attempt=0: cap = min(60, 2 * 2^0) = 2 → delay in [0, 2]
+        with patch("nexus_mcp.runners.base.random.uniform", return_value=1.5) as mock_uniform:
+            delay = runner._compute_backoff(0, retry_after=None)
+
+        mock_uniform.assert_called_once_with(0, 2.0)
+        assert delay == 1.5
+
+    def test_compute_backoff_respects_retry_after_hint(self, runner):
+        """retry_after hint is used when larger than computed backoff."""
+        runner.base_delay = 2.0
+        runner.max_delay = 60.0
+
+        with patch("nexus_mcp.runners.base.random.uniform", return_value=0.5):
+            delay = runner._compute_backoff(0, retry_after=30.0)
+
+        # computed=0.5, retry_after=30 → max(0.5, 30) = 30
+        assert delay == 30.0
+
+    def test_compute_backoff_computed_wins_when_larger_than_retry_after(self, runner):
+        """Computed delay is used when larger than retry_after hint."""
+        runner.base_delay = 2.0
+        runner.max_delay = 60.0
+
+        with patch("nexus_mcp.runners.base.random.uniform", return_value=1.8):
+            delay = runner._compute_backoff(0, retry_after=0.1)
+
+        # computed=1.8, retry_after=0.1 → max(1.8, 0.1) = 1.8
+        assert delay == 1.8
+
+    async def test_max_retries_1_means_single_attempt(self, runner):
+        """max_retries=1 runs exactly once with no retry on failure."""
+        retryable = RetryableError("rate limit", returncode=429)
+        runner._execute = AsyncMock(side_effect=retryable)  # type: ignore[method-assign]
+        request = make_prompt_request(max_retries=1)
+
+        with pytest.raises(RetryableError):
+            await runner.run(request)
+
+        assert runner._execute.await_count == 1
+
+    @patch("nexus_mcp.process.asyncio.create_subprocess_exec")
+    async def test_max_retries_none_falls_back_to_env_default(self, mock_exec, runner):
+        """max_retries=None uses runner.default_max_attempts (from env)."""
+        retryable = RetryableError("rate limit")
+        runner._execute = AsyncMock(side_effect=retryable)  # type: ignore[method-assign]
+        runner.default_max_attempts = 4
+        request = make_prompt_request(max_retries=None)
+
+        with pytest.raises(RetryableError):
+            await runner.run(request)
+
+        assert runner._execute.await_count == 4
+
+    @patch("nexus_mcp.process.asyncio.create_subprocess_exec")
+    async def test_backoff_called_between_attempts(self, mock_exec, runner):
+        """asyncio.sleep is called (max_attempts - 1) times between attempts."""
+        retryable = RetryableError("rate limit")
+        runner._execute = AsyncMock(side_effect=retryable)  # type: ignore[method-assign]
+        request = make_prompt_request(max_retries=3)
+
+        sleep_calls: list[float] = []
+
+        async def capture_sleep(delay: float) -> None:
+            sleep_calls.append(delay)
+
+        with patch("asyncio.sleep", side_effect=capture_sleep), pytest.raises(RetryableError):
+            await runner.run(request)
+
+        # 3 attempts → 2 sleeps (no sleep after the last attempt)
+        assert len(sleep_calls) == 2

--- a/tests/unit/runners/test_gemini.py
+++ b/tests/unit/runners/test_gemini.py
@@ -12,7 +12,7 @@ from unittest.mock import patch
 import pytest
 
 from nexus_mcp.cli_detector import CLIInfo
-from nexus_mcp.exceptions import CLINotFoundError, ParseError, SubprocessError
+from nexus_mcp.exceptions import CLINotFoundError, ParseError, RetryableError, SubprocessError
 from nexus_mcp.runners.gemini import GeminiRunner
 from tests.fixtures import (
     GEMINI_JSON_RESPONSE,
@@ -777,6 +777,98 @@ class TestGaxiosErrorExtraction:
         primary_message = exc_info.value.args[0]
         assert "Gemini API error" not in primary_message
         assert "CLI command failed" in primary_message
+
+
+class TestGeminiRunnerRetryableErrors:
+    """Test GeminiRunner raises RetryableError for transient error codes (429, 503).
+
+    These tests verify _try_extract_error classifies codes correctly and
+    that the retry loop in run() triggers on RetryableError.
+    """
+
+    @patch("nexus_mcp.process.asyncio.create_subprocess_exec")
+    async def test_429_raises_retryable_error(self, mock_exec):
+        """HTTP 429 (rate limit) → RetryableError, not plain SubprocessError."""
+        error_stdout = (
+            '{"error": {"code": 429, "message": "Quota exceeded", "status": "RESOURCE_EXHAUSTED"}}'
+        )
+        mock_exec.return_value = create_mock_process(stdout=error_stdout, stderr="", returncode=1)
+        runner = GeminiRunner()
+        request = make_prompt_request(max_retries=1)  # single attempt to isolate behavior
+
+        with pytest.raises(RetryableError) as exc_info:
+            await runner.run(request)
+
+        assert exc_info.value.returncode == 1
+        assert "429" in exc_info.value.args[0]
+
+    @patch("nexus_mcp.process.asyncio.create_subprocess_exec")
+    async def test_503_raises_retryable_error(self, mock_exec):
+        """HTTP 503 (service unavailable) → RetryableError."""
+        error_stdout = (
+            '{"error": {"code": 503, "message": "Service unavailable", "status": "UNAVAILABLE"}}'
+        )
+        mock_exec.return_value = create_mock_process(stdout=error_stdout, stderr="", returncode=1)
+        runner = GeminiRunner()
+        request = make_prompt_request(max_retries=1)
+
+        with pytest.raises(RetryableError) as exc_info:
+            await runner.run(request)
+
+        assert "503" in exc_info.value.args[0]
+
+    @patch("nexus_mcp.process.asyncio.create_subprocess_exec")
+    async def test_401_raises_non_retryable_subprocess_error(self, mock_exec):
+        """HTTP 401 (auth failure) → plain SubprocessError, NOT RetryableError."""
+        error_stdout = (
+            '{"error": {"code": 401, "message": "API key not valid", "status": "UNAUTHENTICATED"}}'
+        )
+        mock_exec.return_value = create_mock_process(stdout=error_stdout, stderr="", returncode=1)
+        runner = GeminiRunner()
+        request = make_prompt_request(max_retries=1)
+
+        with pytest.raises(SubprocessError) as exc_info:
+            await runner.run(request)
+
+        # Verify it's NOT a RetryableError subclass
+        assert not isinstance(exc_info.value, RetryableError)
+        assert "401" in exc_info.value.args[0]
+
+    @patch("nexus_mcp.process.asyncio.create_subprocess_exec")
+    async def test_gaxios_429_in_stderr_raises_retryable_error(self, mock_exec):
+        """GaxiosError 429 embedded in stderr JSON array → RetryableError."""
+        stderr_with_429 = (
+            "Gemini CLI encountered an API error\n"
+            '[{"error": {"code": 429, "message": "No capacity", "status": "RESOURCE_EXHAUSTED"}}]'
+        )
+        mock_exec.return_value = create_mock_process(
+            stdout="", stderr=stderr_with_429, returncode=1
+        )
+        runner = GeminiRunner()
+        request = make_prompt_request(max_retries=1)
+
+        with pytest.raises(RetryableError) as exc_info:
+            await runner.run(request)
+
+        assert "429" in exc_info.value.args[0]
+
+    @patch("nexus_mcp.process.asyncio.create_subprocess_exec")
+    async def test_retry_on_429_succeeds_on_second_attempt(self, mock_exec):
+        """Full integration: first call returns 429 RetryableError, second succeeds."""
+        error_stdout = (
+            '{"error": {"code": 429, "message": "Quota exceeded", "status": "RESOURCE_EXHAUSTED"}}'
+        )
+        mock_exec.side_effect = [
+            create_mock_process(stdout=error_stdout, stderr="", returncode=1),
+            create_mock_process(stdout='{"response": "Success after retry"}', returncode=0),
+        ]
+        runner = GeminiRunner()
+        request = make_prompt_request(max_retries=2)
+
+        response = await runner.run(request)
+
+        assert response.output == "Success after retry"
+        assert mock_exec.await_count == 2
 
 
 class TestGeminiRunnerEnvConfiguration:

--- a/tests/unit/runners/test_runner_pipeline.py
+++ b/tests/unit/runners/test_runner_pipeline.py
@@ -5,6 +5,7 @@ Verifies all runner features work together in a single execution:
 2. Error recovery (parse stdout despite non-zero exit)
 3. File references (appended to prompt)
 4. Environment variable configuration (custom path, model, limits)
+5. Retry + output truncation work together end-to-end
 """
 
 import os
@@ -56,3 +57,29 @@ async def test_all_enhancements_together(mock_exec):
     # 4. Output was truncated
     assert response.metadata.get("truncated") is True
     assert len(response.output.encode("utf-8")) <= 1000
+
+
+@patch("nexus_mcp.process.asyncio.create_subprocess_exec")
+async def test_retry_and_output_truncation_together(mock_exec):
+    """Verify retry + output truncation work together: fail once, then succeed with large output."""
+    error_stdout = (
+        '{"error": {"code": 429, "message": "Quota exceeded", "status": "RESOURCE_EXHAUSTED"}}'
+    )
+    # Use output larger than the 50KB default limit to guarantee truncation
+    large_output = "y" * 60_000
+    mock_exec.side_effect = [
+        create_mock_process(stdout=error_stdout, returncode=1),  # 429 → RetryableError
+        create_mock_process(stdout='{"response": "' + large_output + '"}', returncode=0),  # success
+    ]
+
+    runner = GeminiRunner()
+    request = make_prompt_request(prompt="test", max_retries=2)
+
+    response = await runner.run(request)
+
+    # Retried after 429 and succeeded
+    assert mock_exec.await_count == 2
+
+    # Output was truncated after retry success (60KB > 50KB default limit)
+    assert response.metadata.get("truncated") is True
+    assert len(response.output.encode("utf-8")) <= 50_000

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -5,7 +5,14 @@ from unittest.mock import patch
 
 import pytest
 
-from nexus_mcp.config import get_agent_env, get_global_output_limit, get_global_timeout
+from nexus_mcp.config import (
+    get_agent_env,
+    get_global_output_limit,
+    get_global_timeout,
+    get_retry_base_delay,
+    get_retry_max_attempts,
+    get_retry_max_delay,
+)
 from nexus_mcp.exceptions import ConfigurationError
 
 
@@ -55,6 +62,74 @@ class TestGetGlobalTimeout:
 
         assert exc_info.value.config_key == "NEXUS_TIMEOUT_SECONDS"
         assert "Invalid timeout value: 'abc'" in str(exc_info.value)
+
+
+class TestGetRetryMaxAttempts:
+    """Test get_retry_max_attempts() function."""
+
+    def test_default_is_three(self):
+        """Max attempts defaults to 3 if env var not set."""
+        assert get_retry_max_attempts() == 3
+
+    @patch.dict(os.environ, {"NEXUS_RETRY_MAX_ATTEMPTS": "5"})
+    def test_custom_value_from_env(self):
+        """Max attempts can be overridden via NEXUS_RETRY_MAX_ATTEMPTS."""
+        assert get_retry_max_attempts() == 5
+
+    @patch.dict(os.environ, {"NEXUS_RETRY_MAX_ATTEMPTS": "not-a-number"})
+    def test_invalid_raises_configuration_error(self):
+        """Invalid value should raise ConfigurationError."""
+        with pytest.raises(ConfigurationError) as exc_info:
+            get_retry_max_attempts()
+        assert exc_info.value.config_key == "NEXUS_RETRY_MAX_ATTEMPTS"
+        assert "Invalid retry max attempts value" in str(exc_info.value)
+
+
+class TestGetRetryBaseDelay:
+    """Test get_retry_base_delay() function."""
+
+    def test_default_is_two_seconds(self):
+        """Base delay defaults to 2.0s if env var not set."""
+        assert get_retry_base_delay() == 2.0
+
+    @patch.dict(os.environ, {"NEXUS_RETRY_BASE_DELAY": "0.5"})
+    def test_custom_float_from_env(self):
+        """Base delay accepts float values."""
+        assert get_retry_base_delay() == 0.5
+
+    @patch.dict(os.environ, {"NEXUS_RETRY_BASE_DELAY": "1"})
+    def test_integer_string_accepted(self):
+        """Integer string is coerced to float."""
+        assert get_retry_base_delay() == 1.0
+
+    @patch.dict(os.environ, {"NEXUS_RETRY_BASE_DELAY": "not-a-float"})
+    def test_invalid_raises_configuration_error(self):
+        """Invalid value should raise ConfigurationError."""
+        with pytest.raises(ConfigurationError) as exc_info:
+            get_retry_base_delay()
+        assert exc_info.value.config_key == "NEXUS_RETRY_BASE_DELAY"
+        assert "Invalid retry base delay value" in str(exc_info.value)
+
+
+class TestGetRetryMaxDelay:
+    """Test get_retry_max_delay() function."""
+
+    def test_default_is_sixty_seconds(self):
+        """Max delay defaults to 60.0s if env var not set."""
+        assert get_retry_max_delay() == 60.0
+
+    @patch.dict(os.environ, {"NEXUS_RETRY_MAX_DELAY": "30.0"})
+    def test_custom_float_from_env(self):
+        """Max delay can be overridden via NEXUS_RETRY_MAX_DELAY."""
+        assert get_retry_max_delay() == 30.0
+
+    @patch.dict(os.environ, {"NEXUS_RETRY_MAX_DELAY": "bad"})
+    def test_invalid_raises_configuration_error(self):
+        """Invalid value should raise ConfigurationError."""
+        with pytest.raises(ConfigurationError) as exc_info:
+            get_retry_max_delay()
+        assert exc_info.value.config_key == "NEXUS_RETRY_MAX_DELAY"
+        assert "Invalid retry max delay value" in str(exc_info.value)
 
 
 class TestGetAgentEnv:

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -3,6 +3,7 @@ from nexus_mcp.exceptions import (
     ConfigurationError,
     NexusMCPError,
     ParseError,
+    RetryableError,
     SubprocessError,
     SubprocessTimeoutError,
     UnsupportedAgentError,
@@ -175,3 +176,67 @@ def test_subprocess_timeout_error_stdout_defaults_to_empty():
     """SubprocessTimeoutError stdout defaults to empty string."""
     err = SubprocessTimeoutError("Timed out", timeout=30.0)
     assert err.stdout == ""
+
+
+# ---------------------------------------------------------------------------
+# RetryableError tests
+# ---------------------------------------------------------------------------
+
+
+def test_retryable_error_inherits_subprocess_error():
+    """RetryableError should inherit from SubprocessError and NexusMCPError."""
+    assert issubclass(RetryableError, SubprocessError)
+    assert issubclass(RetryableError, NexusMCPError)
+
+
+def test_retryable_error_retry_after_defaults_to_none():
+    """retry_after defaults to None when not provided."""
+    err = RetryableError("Rate limited")
+    assert err.retry_after is None
+
+
+def test_retryable_error_stores_retry_after():
+    """retry_after stores custom wait hint (keyword-only)."""
+    err = RetryableError("Rate limited", retry_after=30.0)
+    assert err.retry_after == 30.0
+
+
+def test_retryable_error_stores_subprocess_fields():
+    """RetryableError stores all SubprocessError fields."""
+    err = RetryableError(
+        "Rate limited",
+        stderr="quota exceeded",
+        command=["gemini", "-p", "test"],
+        returncode=429,
+        stdout='{"error": {"code": 429}}',
+    )
+    assert err.stderr == "quota exceeded"
+    assert err.command == ["gemini", "-p", "test"]
+    assert err.returncode == 429
+    assert err.stdout == '{"error": {"code": 429}}'
+
+
+def test_retryable_error_str_inherits_subprocess_format():
+    """__str__ uses SubprocessError format including returncode and stderr."""
+    err = RetryableError("Rate limited", returncode=429, stderr="quota exceeded")
+    result = str(err)
+    assert "Rate limited" in result
+    assert "returncode=429" in result
+    assert "quota exceeded" in result
+
+
+def test_retryable_error_default_subprocess_fields():
+    """All SubprocessError fields default to empty/None."""
+    err = RetryableError("Rate limited")
+    assert err.stderr == ""
+    assert err.command is None
+    assert err.returncode is None
+    assert err.stdout == ""
+
+
+def test_retryable_error_caught_by_subprocess_error_handler():
+    """pytest.raises(SubprocessError) catches RetryableError (subclass relationship)."""
+    import pytest
+
+    with pytest.raises(SubprocessError):
+        raise RetryableError("Rate limited")

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -145,6 +145,35 @@ class TestPrompt:
             )
 
     @patch("nexus_mcp.server.RunnerFactory")
+    async def test_prompt_passes_max_retries(self, mock_factory, progress):
+        """max_retries parameter is passed through to the PromptRequest."""
+        mock_runner = _setup_mock_runner(mock_factory, output="Done")
+
+        await prompt(
+            agent="gemini",
+            prompt="Test prompt",
+            progress=progress,
+            max_retries=7,
+        )
+
+        call_args = mock_runner.run.call_args.args[0]
+        assert call_args.max_retries == 7
+
+    @patch("nexus_mcp.server.RunnerFactory")
+    async def test_prompt_max_retries_defaults_to_none(self, mock_factory, progress):
+        """max_retries defaults to None when not specified in prompt()."""
+        mock_runner = _setup_mock_runner(mock_factory, output="Done")
+
+        await prompt(
+            agent="gemini",
+            prompt="Test prompt",
+            progress=progress,
+        )
+
+        call_args = mock_runner.run.call_args.args[0]
+        assert call_args.max_retries is None
+
+    @patch("nexus_mcp.server.RunnerFactory")
     async def test_ctx_forwarded_to_batch_prompt(self, mock_factory, progress, ctx):
         """ctx passed to prompt() is forwarded through to batch_prompt()."""
         _setup_mock_runner(mock_factory, output="Done")
@@ -402,3 +431,25 @@ class TestBatchPrompt:
         # Should not raise even though ctx is None (the default)
         result = await batch_prompt(tasks=[make_agent_task()], progress=progress)
         assert isinstance(result, MultiPromptResponse)
+
+    @patch("nexus_mcp.server.RunnerFactory")
+    async def test_batch_prompt_passes_max_retries_to_request(self, mock_factory, progress):
+        """AgentTask.max_retries is threaded through to PromptRequest."""
+        mock_runner = _setup_mock_runner(mock_factory)
+
+        tasks = [make_agent_task(max_retries=5)]
+        await batch_prompt(tasks=tasks, progress=progress)
+
+        call_args = mock_runner.run.call_args.args[0]
+        assert call_args.max_retries == 5
+
+    @patch("nexus_mcp.server.RunnerFactory")
+    async def test_batch_prompt_max_retries_none_by_default(self, mock_factory, progress):
+        """When AgentTask.max_retries is None, PromptRequest.max_retries is also None."""
+        mock_runner = _setup_mock_runner(mock_factory)
+
+        tasks = [make_agent_task()]  # max_retries not specified → None
+        await batch_prompt(tasks=tasks, progress=progress)
+
+        call_args = mock_runner.run.call_args.args[0]
+        assert call_args.max_retries is None

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -186,3 +186,38 @@ def test_multi_prompt_response_counts():
     assert response.total == 3
     assert response.succeeded == 2
     assert response.failed == 1
+
+
+# ---------------------------------------------------------------------------
+# max_retries field tests
+# ---------------------------------------------------------------------------
+
+
+def test_prompt_request_max_retries_defaults_to_none():
+    """PromptRequest.max_retries defaults to None (falls back to env default)."""
+    req = PromptRequest(agent="gemini", prompt="Hello")
+    assert req.max_retries is None
+
+
+def test_prompt_request_max_retries_accepts_custom_value():
+    """PromptRequest.max_retries accepts a positive integer."""
+    req = PromptRequest(agent="gemini", prompt="Hello", max_retries=5)
+    assert req.max_retries == 5
+
+
+def test_prompt_request_max_retries_accepts_one():
+    """max_retries=1 disables retry (run once, no retry on failure)."""
+    req = PromptRequest(agent="gemini", prompt="Hello", max_retries=1)
+    assert req.max_retries == 1
+
+
+def test_agent_task_max_retries_defaults_to_none():
+    """AgentTask.max_retries defaults to None."""
+    task = AgentTask(agent="gemini", prompt="Hello")
+    assert task.max_retries is None
+
+
+def test_agent_task_max_retries_accepts_custom_value():
+    """AgentTask.max_retries accepts a positive integer."""
+    task = AgentTask(agent="gemini", prompt="Hello", max_retries=2)
+    assert task.max_retries == 2


### PR DESCRIPTION
Introduce a robust retry loop for CLI agent executions to handle transient errors like rate limits (429) and service unavailability (503).

- Add RetryableError exception for transient failures
- Implement exponential backoff with full jitter in AbstractRunner
- Support NEXUS_RETRY_* environment variables for global configuration
- Allow per-request max_retries override in PromptRequest and AgentTask
- Update GeminiRunner to identify retryable API status codes
- Add comprehensive tests for retry logic and backoff computation