### PR TITLE
feat(cli): add version flag

### DIFF
--- a/src/nexus_mcp/__init__.py
+++ b/src/nexus_mcp/__init__.py
@@ -1,1 +1,5 @@
 """Nexus MCP - AI CLI Agent MCP Server."""
+
+from importlib.metadata import version
+
+__version__ = version("nexus-mcp")

--- a/src/nexus_mcp/__main__.py
+++ b/src/nexus_mcp/__main__.py
@@ -11,6 +11,12 @@ import sys
 
 
 def main() -> None:
+    if len(sys.argv) == 2 and sys.argv[1] in ("--version", "-V"):
+        from nexus_mcp import __version__
+
+        print(f"nexus-mcp {__version__}")
+        return
+
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s %(name)s %(levelname)s %(message)s",


### PR DESCRIPTION
Expose the package version in __init__.py and implement --version and -V flags to display the current version of nexus-mcp.