### PR TITLE
feat(config): make CLI detection timeout configurable

### DIFF
--- a/src/nexus_mcp/cli_detector.py
+++ b/src/nexus_mcp/cli_detector.py
@@ -16,6 +16,8 @@ from dataclasses import dataclass
 
 from packaging import version as pkg_version
 
+from nexus_mcp.config import get_cli_detection_timeout
+
 
 @dataclass(frozen=True, slots=True)
 class CLIInfo:
@@ -44,7 +46,7 @@ def get_cli_version(cli_name: str) -> str | None:
             [cli_name, "--version"],
             capture_output=True,
             text=True,
-            timeout=10,
+            timeout=get_cli_detection_timeout(),
         )
         return parse_version(result.stdout, cli=cli_name) or parse_version(
             result.stderr, cli=cli_name

--- a/src/nexus_mcp/config.py
+++ b/src/nexus_mcp/config.py
@@ -102,6 +102,21 @@ def get_retry_max_delay() -> float:
     return _get_float_env("NEXUS_RETRY_MAX_DELAY", "60.0", "retry max delay")
 
 
+def get_cli_detection_timeout() -> int:
+    """Get CLI detection timeout in seconds from env var.
+
+    Returns:
+        Timeout in seconds (default: 30s)
+
+    Raises:
+        ConfigurationError: If env var value is not a valid integer
+
+    Environment Variable:
+        NEXUS_CLI_DETECTION_TIMEOUT: Seconds to wait for '<cli> --version'
+    """
+    return _get_int_env("NEXUS_CLI_DETECTION_TIMEOUT", "30", "CLI detection timeout")
+
+
 def get_agent_env(agent: str, key: str, default: str | None = None) -> str | None:
     """Get agent-specific environment variable.
 

--- a/tests/integration/test_cli_detection.py
+++ b/tests/integration/test_cli_detection.py
@@ -11,17 +11,21 @@ import subprocess
 import pytest
 
 from nexus_mcp.cli_detector import detect_cli, get_cli_capabilities, get_cli_version
+from nexus_mcp.config import get_cli_detection_timeout
 
 
 def _run_version_command(cli_name: str) -> str:
     """Run '<cli> --version' and return a diagnostic string for assertion messages."""
+    timeout = get_cli_detection_timeout()
     try:
-        result = subprocess.run([cli_name, "--version"], capture_output=True, text=True, timeout=10)
+        result = subprocess.run(
+            [cli_name, "--version"], capture_output=True, text=True, timeout=timeout
+        )
         return f"returncode={result.returncode}, stdout={result.stdout!r}, stderr={result.stderr!r}"
     except FileNotFoundError:
         return "FileNotFoundError: binary not found"
     except subprocess.TimeoutExpired:
-        return "TimeoutExpired: exceeded 10s"
+        return f"TimeoutExpired: exceeded {timeout}s"
 
 
 # Semver pattern: MAJOR.MINOR.PATCH (optional pre-release suffix handled by parse_version)

--- a/tests/unit/test_cli_detector.py
+++ b/tests/unit/test_cli_detector.py
@@ -4,6 +4,8 @@
 import subprocess
 from unittest.mock import Mock, patch
 
+import pytest
+
 from nexus_mcp.cli_detector import (
     CLIInfo,
     detect_cli,
@@ -40,6 +42,11 @@ class TestDetectCLI:
 
 class TestGetCLIVersion:
     """Test get_cli_version() runs '<cli> --version' and extracts version."""
+
+    @pytest.fixture(autouse=True)
+    def mock_timeout(self):
+        with patch("nexus_mcp.cli_detector.get_cli_detection_timeout", return_value=10):
+            yield
 
     def test_get_cli_version_gemini(self):
         with patch("nexus_mcp.cli_detector.subprocess.run") as mock_run:


### PR DESCRIPTION
Introduce the NEXUS_CLI_DETECTION_TIMEOUT environment variable to allow customization of the subprocess timeout during CLI version detection. The default timeout is increased from 10 to 30 seconds to improve reliability in constrained environments.