### PR TITLE
feat(runners): add support for OpenAI Codex CLI

### DIFF
--- a/src/nexus_mcp/cli_detector.py
+++ b/src/nexus_mcp/cli_detector.py
@@ -51,7 +51,7 @@ def get_cli_version(cli_name: str) -> str | None:
         return parse_version(result.stdout, cli=cli_name) or parse_version(
             result.stderr, cli=cli_name
         )
-    except (FileNotFoundError, subprocess.TimeoutExpired):
+    except (OSError, subprocess.TimeoutExpired):
         pass
     return None
 
@@ -60,7 +60,7 @@ def parse_version(version_output: str, cli: str) -> str | None:
     """Parse version string from CLI --version output."""
     patterns: dict[str, str] = {
         "gemini": r"v?(\d+\.\d+\.\d+(?:-[\w.]+)?)",
-        "codex": r"version\s+(\d+\.\d+\.\d+)",
+        "codex": r"(?:codex[-\w]*|version)\s+(\d+\.\d+\.\d+)",
         "claude": r"v?(\d+\.\d+\.\d+)",
     }
     pattern = patterns.get(cli)

--- a/src/nexus_mcp/parser.py
+++ b/src/nexus_mcp/parser.py
@@ -43,6 +43,10 @@ def extract_last_json_object(text: str) -> dict[str, Any] | None:
     block. Handles CLI patterns of appending a JSON error block at the end of
     stderr that may contain log lines and stack traces.
 
+    Scans rightward-to-left through '}' positions. If the first candidate
+    fails to parse (e.g. '}' appears inside a JSON string value), retries
+    with the next candidate — the same retry strategy used by extract_last_json_array.
+
     Args:
         text: String that may contain JSON, possibly mixed with other content.
 
@@ -52,16 +56,73 @@ def extract_last_json_object(text: str) -> dict[str, Any] | None:
     if not text:
         return None
 
-    span = _find_balanced_span(text, "{", "}", len(text))
-    if span is None:
-        return None
+    search_end = len(text)
+    while True:
+        span = _find_balanced_span(text, "{", "}", search_end)
+        if span is None:
+            return None
 
-    start, end = span
-    try:
-        parsed = json.loads(text[start : end + 1])
-        return parsed if isinstance(parsed, dict) else None
-    except (json.JSONDecodeError, ValueError, RecursionError):
-        return None
+        start, last_close = span
+        with contextlib.suppress(json.JSONDecodeError, ValueError, RecursionError):
+            parsed = json.loads(text[start : last_close + 1])
+            if isinstance(parsed, dict):
+                return parsed
+
+        search_end = last_close
+
+
+def parse_ndjson_events(stdout: str) -> str | None:
+    """Extract agent message text from Codex CLI NDJSON output.
+
+    Codex emits one JSON event object per line. This function collects text
+    from ``item.completed`` events where ``item.type == "agent_message"``,
+    joining them with ``"\\n\\n"``.
+
+    Text extraction precedence (per event):
+        1. ``item["text"]``  — direct text field
+        2. ``item["content"][*]["text"]``  — content block list
+
+    Skips blank lines, non-JSON lines, and non-agent-message events silently
+    (parser contract: return None on failure, never raise).
+
+    Args:
+        stdout: Raw NDJSON output from Codex CLI.
+
+    Returns:
+        Joined text from all agent_message events, or None if nothing found.
+
+    Example NDJSON input::
+
+        {"type": "thread.started", "thread_id": "t1"}
+        {"type": "item.completed", "item": {"id": "i1", "type": "agent_message", "text": "hi"}}
+        {"type": "turn.completed"}
+    """
+    parts: list[str] = []
+    for line in stdout.splitlines():
+        if not line.strip():
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(event, dict) or event.get("type") != "item.completed":
+            continue
+        item = event.get("item")
+        if not isinstance(item, dict) or item.get("type") != "agent_message":
+            continue
+        text = item.get("text")
+        if isinstance(text, str):
+            parts.append(text)
+            continue
+        # Fall back to content block list
+        content = item.get("content")
+        if isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict):
+                    block_text = block.get("text")
+                    if isinstance(block_text, str):
+                        parts.append(block_text)
+    return "\n\n".join(parts) if parts else None
 
 
 def extract_last_json_array(text: str) -> dict[str, Any] | None:

--- a/src/nexus_mcp/runners/base.py
+++ b/src/nexus_mcp/runners/base.py
@@ -23,16 +23,23 @@ import logging
 import random
 import tempfile
 from abc import ABC, abstractmethod
-from typing import Protocol
+from typing import ClassVar, Protocol
 
+from nexus_mcp.cli_detector import (
+    CLICapabilities,
+    detect_cli,
+    get_cli_capabilities,
+    get_cli_version,
+)
 from nexus_mcp.config import (
+    get_agent_env,
     get_global_output_limit,
     get_global_timeout,
     get_retry_base_delay,
     get_retry_max_attempts,
     get_retry_max_delay,
 )
-from nexus_mcp.exceptions import RetryableError, SubprocessError
+from nexus_mcp.exceptions import CLINotFoundError, ParseError, RetryableError, SubprocessError
 from nexus_mcp.process import run_subprocess
 from nexus_mcp.types import AgentResponse, PromptRequest
 
@@ -65,6 +72,9 @@ class CLIRunner(Protocol):
 class AbstractRunner(ABC):
     """Abstract base class implementing Template Method pattern for CLI runners.
 
+    Subclasses must define:
+    - AGENT_NAME: ClassVar[str]  (e.g., "gemini", "codex")
+
     Subclasses must implement:
     - build_command(): Construct CLI command from PromptRequest
     - parse_output(): Parse CLI stdout/stderr into AgentResponse
@@ -77,12 +87,28 @@ class AbstractRunner(ABC):
     5. Apply output limiting
     """
 
+    AGENT_NAME: ClassVar[str]
+    _RETRYABLE_CODES: ClassVar[frozenset[int]] = frozenset({429, 503})
+
     def __init__(self) -> None:
-        """Initialize runner with global configuration."""
+        """Initialize runner with CLI detection and global configuration.
+
+        Raises:
+            CLINotFoundError: If the CLI binary is not found in PATH.
+        """
+        info = detect_cli(self.AGENT_NAME)
+        if not info.found:
+            raise CLINotFoundError(self.AGENT_NAME)
+        version = get_cli_version(self.AGENT_NAME)
+        self.capabilities: CLICapabilities = get_cli_capabilities(self.AGENT_NAME, version)
         self.timeout = get_global_timeout()
         self.base_delay = get_retry_base_delay()
         self.max_delay = get_retry_max_delay()
         self.default_max_attempts = get_retry_max_attempts()
+        self.cli_path: str = (
+            get_agent_env(self.AGENT_NAME, "PATH", default=self.AGENT_NAME) or self.AGENT_NAME
+        )
+        self.default_model: str | None = get_agent_env(self.AGENT_NAME, "MODEL")
 
     async def run(self, request: PromptRequest) -> AgentResponse:
         """Execute CLI agent with retry on transient errors.
@@ -236,6 +262,20 @@ class AbstractRunner(ABC):
             truncated_size_bytes=len(truncated_output.encode("utf-8")),
         )
 
+    def _build_prompt(self, request: PromptRequest) -> str:
+        """Build prompt string with optional file references appended.
+
+        Args:
+            request: Prompt request potentially containing file_refs.
+
+        Returns:
+            Prompt string with file references appended if present.
+        """
+        if not request.file_refs:
+            return request.prompt
+        file_list = "\n".join(f"- {path}" for path in request.file_refs)
+        return f"{request.prompt}\n\nFile references:\n{file_list}"
+
     def _make_recovered_response(
         self, response: AgentResponse, returncode: int, stderr: str
     ) -> AgentResponse:
@@ -260,7 +300,7 @@ class AbstractRunner(ABC):
     ) -> None:
         """Hook for subclasses to raise structured errors from CLI output.
 
-        Called by _recover_from_error implementations when parse_output fails.
+        Called by _recover_from_error when parse_output fails.
         Default: no-op. Override to inspect stdout/stderr for agent-specific
         error formats and raise SubprocessError with structured details.
 
@@ -277,8 +317,9 @@ class AbstractRunner(ABC):
     ) -> AgentResponse | None:
         """Attempt to recover from subprocess error.
 
-        Default implementation returns None (no recovery). Subclasses can override
-        to implement CLI-specific recovery strategies.
+        Tries to parse stdout as valid output even on non-zero exit code.
+        If parsing fails, calls _try_extract_error() to surface structured
+        errors from stdout/stderr before falling through to the generic error.
 
         Args:
             stdout: Subprocess stdout
@@ -290,10 +331,16 @@ class AbstractRunner(ABC):
             Recovered AgentResponse or None if recovery not possible.
 
         Raises:
-            SubprocessError: Subclass implementations may raise if a structured error is
-                detected in stdout/stderr (e.g. GeminiRunner raises on API error JSON).
+            SubprocessError: If _try_extract_error detects a structured error in
+                stdout/stderr (e.g., API error JSON with code and message).
         """
-        return None
+        try:
+            response = self.parse_output(stdout, stderr)
+            return self._make_recovered_response(response, returncode, stderr)
+        except ParseError:
+            # Try to extract structured API error; raises SubprocessError if found
+            self._try_extract_error(stdout, stderr, returncode, command)
+            return None  # Falls through to base.py's generic SubprocessError
 
     @abstractmethod
     def build_command(self, request: PromptRequest) -> list[str]:

--- a/src/nexus_mcp/runners/codex.py
+++ b/src/nexus_mcp/runners/codex.py
@@ -1,0 +1,140 @@
+# src/nexus_mcp/runners/codex.py
+"""Codex CLI runner implementation.
+
+Executes OpenAI's Codex CLI with NDJSON output format.
+
+Command format:
+    codex exec "<prompt>" --json [--model <model>] [--sandbox workspace-write|--yolo]
+
+Expected NDJSON response (one JSON object per line):
+    {"type": "thread.started", "thread_id": "..."}
+    {"type": "item.completed", "item": {"id": "...", "type": "agent_message", "text": "..."}}
+    {"type": "turn.completed", "turn_id": "..."}
+"""
+
+import contextlib
+
+from nexus_mcp.exceptions import ParseError, RetryableError, SubprocessError
+from nexus_mcp.parser import extract_last_json_object, parse_ndjson_events
+from nexus_mcp.runners.base import AbstractRunner
+from nexus_mcp.types import AgentResponse, PromptRequest
+
+
+class CodexRunner(AbstractRunner):
+    """Runner for OpenAI Codex CLI.
+
+    Builds commands in format:
+        codex exec <prompt> --json [options]
+
+    Parses NDJSON responses, collecting text from agent_message events.
+    """
+
+    AGENT_NAME = "codex"
+
+    def build_command(self, request: PromptRequest) -> list[str]:
+        """Build Codex CLI command from request.
+
+        Args:
+            request: PromptRequest with prompt, model, execution_mode, file_refs.
+
+        Returns:
+            Command list: [cli_path, "exec", <prompt>, "--json", ...]
+
+        Command structure:
+            1. Base: {cli_path} exec <prompt> (with file_refs appended if provided)
+            2. Add --json
+            3. Add --model <model> (request.model > env default > CLI default)
+            4. Add --sandbox workspace-write if execution_mode == "sandbox"
+            5. Add --yolo if execution_mode == "yolo"
+        """
+        command = [self.cli_path, "exec", self._build_prompt(request), "--json"]
+
+        model = request.model or self.default_model
+        if model:
+            command.extend(["--model", model])
+
+        match request.execution_mode:
+            case "sandbox":
+                command.extend(["--sandbox", "workspace-write"])
+            case "yolo":
+                command.append("--yolo")
+            case _:
+                pass
+
+        return command
+
+    def parse_output(self, stdout: str, stderr: str) -> AgentResponse:
+        """Parse Codex CLI NDJSON output into AgentResponse.
+
+        Args:
+            stdout: NDJSON output from Codex CLI (one event per line).
+            stderr: Standard error output (not used for parsing).
+
+        Returns:
+            AgentResponse with:
+                - agent: "codex"
+                - output: Stripped joined text from agent_message events
+                - raw_output: Original stdout
+
+        Raises:
+            ParseError: If no agent_message text can be extracted.
+        """
+        output = parse_ndjson_events(stdout)
+        if output is None:
+            raise ParseError(
+                "No agent_message text found in Codex CLI NDJSON output",
+                raw_output=stdout,
+            )
+        return AgentResponse(
+            agent=self.AGENT_NAME,
+            output=output.strip(),
+            raw_output=stdout,
+        )
+
+    def _try_extract_error(
+        self,
+        stdout: str,
+        stderr: str,
+        returncode: int,
+        command: list[str] | None = None,
+    ) -> None:
+        """Extract and raise a structured API error from stderr or stdout JSON.
+
+        Args:
+            stdout: Subprocess stdout to inspect as fallback.
+            stderr: Subprocess stderr inspected first.
+            returncode: Exit code (passed through to SubprocessError).
+            command: The CLI command that was run (passed through to SubprocessError).
+
+        Raises:
+            SubprocessError: If stderr or stdout contains an error object.
+        """
+        data = extract_last_json_object(stderr) or extract_last_json_object(stdout)
+        if data is None:
+            return
+
+        error = data.get("error")
+        if not isinstance(error, dict):
+            return
+
+        code = error.get("code", "unknown")
+        if isinstance(code, str):
+            with contextlib.suppress(ValueError):
+                code = int(code)
+        message = error.get("message", "unknown error")
+        error_msg = f"Codex API error {code}: {message}"
+        if isinstance(code, int) and code in self._RETRYABLE_CODES:
+            raise RetryableError(
+                error_msg,
+                stderr=stderr,
+                stdout=stdout,
+                returncode=returncode,
+                command=command,
+            )
+        raise SubprocessError(
+            error_msg,
+            stderr=stderr,
+            stdout=stdout,
+            returncode=returncode,
+            command=command,
+        )

--- a/src/nexus_mcp/runners/factory.py
+++ b/src/nexus_mcp/runners/factory.py
@@ -12,6 +12,7 @@ Usage:
 
 from nexus_mcp.exceptions import UnsupportedAgentError
 from nexus_mcp.runners.base import AbstractRunner
+from nexus_mcp.runners.codex import CodexRunner
 from nexus_mcp.runners.gemini import GeminiRunner
 
 
@@ -28,6 +29,7 @@ class RunnerFactory:
     """
 
     _REGISTRY: dict[str, type[AbstractRunner]] = {
+        CodexRunner.AGENT_NAME: CodexRunner,
         GeminiRunner.AGENT_NAME: GeminiRunner,
     }
 

--- a/src/nexus_mcp/runners/gemini.py
+++ b/src/nexus_mcp/runners/gemini.py
@@ -15,14 +15,10 @@ import contextlib
 import json
 from typing import Any
 
-from nexus_mcp.cli_detector import detect_cli, get_cli_capabilities, get_cli_version
-from nexus_mcp.config import get_agent_env
-from nexus_mcp.exceptions import CLINotFoundError, ParseError, RetryableError, SubprocessError
+from nexus_mcp.exceptions import ParseError, RetryableError, SubprocessError
 from nexus_mcp.parser import extract_last_json_array, extract_last_json_object
 from nexus_mcp.runners.base import AbstractRunner
 from nexus_mcp.types import AgentResponse, PromptRequest
-
-_RETRYABLE_CODES: frozenset[int] = frozenset({429, 503})
 
 
 class GeminiRunner(AbstractRunner):
@@ -35,27 +31,7 @@ class GeminiRunner(AbstractRunner):
         {"response": "text", "stats": {...}}
     """
 
-    AGENT_NAME: str = "gemini"
-
-    def __init__(self) -> None:
-        """Initialize GeminiRunner with CLI detection and env configuration.
-
-        Raises:
-            CLINotFoundError: If gemini CLI is not found in PATH.
-        """
-        # Phase 3: CLI detection
-        info = detect_cli(self.AGENT_NAME)
-        if not info.found:
-            raise CLINotFoundError(self.AGENT_NAME)
-        version = get_cli_version(self.AGENT_NAME)
-        self.capabilities = get_cli_capabilities(self.AGENT_NAME, version)
-
-        # Phase 3.7: env config layer
-        super().__init__()  # sets self.timeout from AbstractRunner
-        self.cli_path: str = (
-            get_agent_env(self.AGENT_NAME, "PATH", default=self.AGENT_NAME) or self.AGENT_NAME
-        )
-        self.default_model: str | None = get_agent_env(self.AGENT_NAME, "MODEL")
+    AGENT_NAME = "gemini"
 
     def build_command(self, request: PromptRequest) -> list[str]:
         """Build Gemini CLI command from request.
@@ -73,14 +49,7 @@ class GeminiRunner(AbstractRunner):
             4. Add --sandbox if execution_mode == "sandbox"
             5. Add --yolo if execution_mode == "yolo"
         """
-        # Build prompt with file references if provided
-        prompt = request.prompt
-        if request.file_refs:
-            file_list = "\n".join(f"- {path}" for path in request.file_refs)
-            prompt = f"{prompt}\n\nFile references:\n{file_list}"
-
-        # Use configured CLI path
-        command = [self.cli_path, "-p", prompt]
+        command = [self.cli_path, "-p", self._build_prompt(request)]
 
         # Add --output-format json if supported by CLI version
         if self.capabilities.supports_json:
@@ -207,12 +176,15 @@ class GeminiRunner(AbstractRunner):
             return
 
         code = error.get("code", "unknown")
+        if isinstance(code, str):
+            with contextlib.suppress(ValueError):
+                code = int(code)
         message = error.get("message", "unknown error")
         status = error.get("status", "")
         if code == 1 and message == "[object Object]":
             return
         error_msg = f"Gemini API error {code}: {message} ({status})"
-        if isinstance(code, int) and code in _RETRYABLE_CODES:
+        if isinstance(code, int) and code in self._RETRYABLE_CODES:
             raise RetryableError(
                 error_msg,
                 stderr=stderr,
@@ -227,32 +199,3 @@ class GeminiRunner(AbstractRunner):
             returncode=returncode,
             command=command,
         )
-
-    def _recover_from_error(
-        self, stdout: str, stderr: str, returncode: int, command: list[str] | None = None
-    ) -> AgentResponse | None:
-        """Attempt to parse stdout even on non-zero exit code.
-
-        Gemini CLI sometimes produces valid JSON in stdout even when
-        encountering errors (e.g., rate limits, warnings). If stdout contains
-        a structured API error object, raises a descriptive SubprocessError.
-
-        Args:
-            stdout: Subprocess stdout
-            stderr: Subprocess stderr
-            returncode: Exit code
-            command: The CLI command that was run (forwarded to SubprocessError if raised).
-
-        Returns:
-            Recovered AgentResponse if stdout is valid JSON, None otherwise
-
-        Raises:
-            SubprocessError: If stdout or stderr contains a Gemini API error object.
-        """
-        try:
-            response = self.parse_output(stdout, stderr)
-            return self._make_recovered_response(response, returncode, stderr)
-        except ParseError:
-            # Try to extract structured API error; raises SubprocessError if found
-            self._try_extract_error(stdout, stderr, returncode, command)
-            return None  # Falls through to base.py's generic SubprocessError

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,11 +5,14 @@ Fixtures here are available in tests/unit/ and tests/integration/ without
 any additional imports.
 """
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastmcp import Context
 from fastmcp.server.dependencies import InMemoryProgress
+
+from nexus_mcp.runners.factory import RunnerFactory
+from tests.fixtures import cli_detection_mocks
 
 
 @pytest.fixture
@@ -35,3 +38,45 @@ def ctx() -> AsyncMock:
     verify ctx.info() logging behavior.
     """
     return AsyncMock(spec=Context)
+
+
+@pytest.fixture
+def mock_cli_detection():
+    """Mock CLI detection so tests don't require real CLI binaries installed.
+
+    NOT autouse — subdirectory conftest files wrap this as autouse for their
+    respective test directories. Tests that need it explicitly can also request
+    it by name.
+    """
+    with cli_detection_mocks() as mock:
+        yield mock
+
+
+@pytest.fixture
+def fast_retry_sleep(monkeypatch):
+    """Patch asyncio.sleep to be instant for retry backoff tests.
+
+    NOT autouse — the runners/ conftest wraps this as autouse for unit tests.
+    E2E tests have their own variant that patches _compute_backoff instead
+    (to avoid busy-spinning the Docket worker's 250ms polling loop).
+    """
+
+    async def instant_sleep(_: float) -> None:
+        pass
+
+    monkeypatch.setattr("asyncio.sleep", instant_sleep)
+
+
+@pytest.fixture
+def mock_subprocess():
+    """Patch asyncio.create_subprocess_exec at the process module boundary.
+
+    All layers above the subprocess call run for real:
+        tool/runner → build_command → run_subprocess → [MOCK]
+
+    Clears RunnerFactory cache on teardown to prevent runner instances from
+    leaking between tests.
+    """
+    with patch("nexus_mcp.process.asyncio.create_subprocess_exec") as mock_exec:
+        yield mock_exec
+    RunnerFactory.clear_cache()

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -9,40 +9,20 @@ boundary, letting all layers above run for real:
         → GeminiRunner → build_command → [MOCK subprocess]
 """
 
-from unittest.mock import patch
-
 import pytest
 from fastmcp import Client
 
 from nexus_mcp.server import mcp
-from tests.fixtures import cli_detection_mocks
 
 
 @pytest.fixture(autouse=True)
-def mock_cli_detection():
-    """Auto-mock CLI detection for all E2E tests.
+def _auto_mock_cli_detection(mock_cli_detection):
+    """Auto-activate CLI detection mocking for all E2E tests.
 
-    GeminiRunner.__init__ calls detect_cli() and get_cli_version().
-    Mock both so tests don't require the real Gemini CLI installed.
-    Clears RunnerFactory cache on teardown to prevent runner instances
-    built under mocked CLI detection from leaking into subsequent tests.
+    Prevents tests from requiring real CLI binaries. RunnerFactory cache
+    is cleared on teardown (via cli_detection_mocks in the root fixture).
     """
-    with cli_detection_mocks() as mock:
-        yield mock
-
-
-@pytest.fixture
-def mock_subprocess():
-    """Patch asyncio.create_subprocess_exec at the process module boundary.
-
-    All layers above the subprocess call run for real through the MCP protocol:
-        Client (JSON-RPC) → FastMCP server → tool functions → RunnerFactory
-            → GeminiRunner → build_command → run_subprocess → [MOCK]
-
-    Clears RunnerFactory cache on teardown to prevent runner instances from leaking.
-    """
-    with patch("nexus_mcp.process.asyncio.create_subprocess_exec") as mock_exec:
-        yield mock_exec
+    yield mock_cli_detection
 
 
 @pytest.fixture

--- a/tests/e2e/test_mcp_protocol.py
+++ b/tests/e2e/test_mcp_protocol.py
@@ -77,11 +77,11 @@ class TestToolDiscovery:
 class TestListAgentsProtocol:
     """Verify list_agents tool via the MCP protocol."""
 
-    async def test_list_agents_returns_gemini(self, mcp_client):
-        """call_tool('list_agents') returns ['gemini'] through JSON-RPC."""
+    async def test_list_agents_returns_all_agents(self, mcp_client):
+        """call_tool('list_agents') returns all supported agents through JSON-RPC."""
         result = await mcp_client.call_tool("list_agents", {})
         assert result.is_error is False
-        assert result.data == ["gemini"]
+        assert result.data == ["codex", "gemini"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -40,8 +40,15 @@ GEMINI_NOISY_STDOUT = (
     '{"response": "test output"}'
 )
 
-# Phase 6/7: Add CODEX_NDJSON_RESPONSE and CLAUDE_JSON_RESPONSE constants
-# when implementing CodexRunner and ClaudeCodeRunner respectively.
+CODEX_NDJSON_RESPONSE = "\n".join(
+    [
+        '{"type": "thread.started", "thread_id": "t1"}',
+        '{"type": "item.completed", "item": {"id": "i1", "type": "agent_message", "text": "pong"}}',
+        '{"type": "turn.completed", "turn_id": "r1"}',
+    ]
+)
+
+# Phase 7: Add CLAUDE_JSON_RESPONSE when implementing ClaudeCodeRunner.
 
 # ---------------------------------------------------------------------------
 # Integration test constants
@@ -71,8 +78,8 @@ def cli_detection_mocks():
                 yield mock
     """
     with (
-        patch("nexus_mcp.runners.gemini.detect_cli") as mock_detect,
-        patch("nexus_mcp.runners.gemini.get_cli_version", return_value="0.12.0"),
+        patch("nexus_mcp.runners.base.detect_cli") as mock_detect,
+        patch("nexus_mcp.runners.base.get_cli_version", return_value="0.12.0"),
     ):
         mock_detect.return_value = CLIInfo(found=True, path="/usr/bin/gemini")
         yield mock_detect

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -9,6 +9,7 @@ import shutil
 
 import pytest
 
+from nexus_mcp.runners.codex import CodexRunner
 from nexus_mcp.runners.gemini import GeminiRunner
 
 
@@ -33,3 +34,26 @@ def gemini_runner(gemini_cli_available: str) -> GeminiRunner:  # noqa: ARG001
     Depends on gemini_cli_available to skip if CLI is absent.
     """
     return GeminiRunner()
+
+
+@pytest.fixture(scope="session")
+def codex_cli_available() -> str:
+    """Skip all dependent tests if Codex CLI is not installed.
+
+    Returns:
+        Full path to the codex binary.
+    """
+    path = shutil.which("codex")
+    if path is None:
+        pytest.skip("Codex CLI not found in PATH — install to run integration tests")
+    return path  # type: ignore[return-value]
+
+
+@pytest.fixture
+def codex_runner(codex_cli_available: str) -> CodexRunner:  # noqa: ARG001
+    """Create a real CodexRunner per test.
+
+    Fresh instance per test to avoid state leakage between tests.
+    Depends on codex_cli_available to skip if CLI is absent.
+    """
+    return CodexRunner()

--- a/tests/integration/test_codex_runner.py
+++ b/tests/integration/test_codex_runner.py
@@ -1,0 +1,90 @@
+# tests/integration/test_codex_runner.py
+"""Integration tests for CodexRunner end-to-end pipeline.
+
+Tests exercise the full Template Method pipeline:
+  build_command() → run_subprocess() → parse_output()
+using the real Codex CLI binary.
+
+Tests marked @slow make real API calls and require a valid API key / auth config.
+"""
+
+import shutil
+
+import pytest
+
+from nexus_mcp.runners.codex import CodexRunner
+from nexus_mcp.types import AgentResponse
+from tests.fixtures import PING_PROMPT, make_prompt_request
+
+
+@pytest.mark.integration
+class TestCodexRunnerConstruction:
+    """Validate CodexRunner.__init__() with real CLI detection."""
+
+    def test_construction_succeeds_with_real_cli(self, codex_cli_available: str) -> None:  # noqa: ARG002
+        """CodexRunner() should construct without error when CLI is installed."""
+        runner = CodexRunner()
+
+        assert runner is not None
+        assert runner.capabilities.found is True
+
+    def test_construction_sets_timeout(self, codex_cli_available: str) -> None:  # noqa: ARG002
+        """CodexRunner should inherit a positive timeout from AbstractRunner."""
+        runner = CodexRunner()
+
+        assert runner.timeout > 0
+
+
+@pytest.mark.integration
+class TestCodexRunnerBuildCommand:
+    """Validate command building with real CLI detection."""
+
+    def test_build_command_includes_json_flag(self, codex_runner: CodexRunner) -> None:
+        """build_command() should include --json flag."""
+        request = make_prompt_request(agent="codex", prompt="test")
+        command = codex_runner.build_command(request)
+
+        assert "--json" in command
+
+    def test_build_command_includes_exec_subcommand(self, codex_runner: CodexRunner) -> None:
+        """build_command() should use 'exec' subcommand."""
+        request = make_prompt_request(agent="codex", prompt="test")
+        command = codex_runner.build_command(request)
+
+        assert "exec" in command
+
+    def test_build_command_cli_path_is_real(self, codex_runner: CodexRunner) -> None:
+        """build_command() CLI path should resolve to an installed binary."""
+        request = make_prompt_request(agent="codex", prompt="test")
+        command = codex_runner.build_command(request)
+
+        assert shutil.which(command[0]) is not None, (
+            f"CLI path {command[0]!r} does not resolve to an installed binary"
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+class TestCodexRunnerEndToEnd:
+    """Full Template Method pipeline with real Codex API calls."""
+
+    async def test_run_simple_prompt_returns_agent_response(
+        self, codex_runner: CodexRunner
+    ) -> None:
+        """run() should return an AgentResponse with non-empty output."""
+        request = make_prompt_request(agent="codex", prompt=PING_PROMPT)
+        response = await codex_runner.run(request)
+
+        assert isinstance(response, AgentResponse)
+        assert response.agent == "codex"
+        assert len(response.output) > 0
+
+    async def test_run_returns_parsed_output(self, codex_runner: CodexRunner) -> None:
+        """run() should populate all AgentResponse fields from parsed NDJSON."""
+        request = make_prompt_request(agent="codex", prompt=PING_PROMPT)
+        response = await codex_runner.run(request)
+
+        assert isinstance(response.output, str)
+        assert isinstance(response.raw_output, str)
+        assert isinstance(response.metadata, dict)
+        assert len(response.raw_output) > 0

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,18 +1,7 @@
 # tests/unit/conftest.py
-"""Shared fixtures for unit tests outside the runners/ directory."""
+"""Shared fixtures for unit tests outside the runners/ directory.
 
-import pytest
-
-from tests.fixtures import cli_detection_mocks
-
-
-@pytest.fixture
-def mock_cli_detection():
-    """Mock CLI detection for tests that use GeminiRunner outside runners/.
-
-    NOT autouse — only tests that explicitly use this fixture will get the mocks.
-    This is for tests like test_extension_points.py that instantiate GeminiRunner
-    via RunnerFactory.create("gemini").
-    """
-    with cli_detection_mocks() as mock:
-        yield mock
+Fixtures from tests/conftest.py (mock_cli_detection, fast_retry_sleep,
+mock_subprocess) are available here automatically via pytest's fixture
+inheritance — no re-definition needed.
+"""

--- a/tests/unit/runners/conftest.py
+++ b/tests/unit/runners/conftest.py
@@ -1,37 +1,30 @@
 # tests/unit/runners/conftest.py
-"""Shared fixtures for runner tests."""
+"""Shared fixtures for runner tests.
+
+Autouse wrappers ensure mock_cli_detection and fast_retry_sleep are active
+for every test in this directory without requiring explicit fixture requests.
+The underlying fixtures live in tests/conftest.py to avoid duplication.
+"""
 
 import pytest
 
-from tests.fixtures import cli_detection_mocks
+
+@pytest.fixture(autouse=True)
+def _auto_mock_cli_detection(mock_cli_detection):
+    """Auto-activate CLI detection mocking for all runner unit tests.
+
+    GeminiRunner/CodexRunner.__init__ calls detect_cli() and get_cli_version().
+    Mocking both prevents tests from requiring actual CLI binaries installed.
+    RunnerFactory cache is cleared on teardown (via cli_detection_mocks).
+    """
+    yield mock_cli_detection
 
 
 @pytest.fixture(autouse=True)
-def mock_cli_detection():
-    """Auto-mock CLI detection for all runner tests.
+def _auto_fast_retry_sleep(fast_retry_sleep):
+    """Auto-activate instant asyncio.sleep for all runner unit tests.
 
-    GeminiRunner.__init__ calls detect_cli() and get_cli_version().
-    Mock both so tests don't require actual Gemini CLI installed.
-    get_cli_capabilities is NOT mocked — it runs with the mocked version
-    ("0.12.0" → supports_json=True), keeping existing command assertions valid.
-
-    Also clears the RunnerFactory cache on teardown so cached runner instances
-    built under mocked CLI detection don't leak into subsequent tests.
+    Prevents real waiting during retry backoff loops in runner tests.
+    Tests in tests/unit/test_process.py (timeout tests) are unaffected
+    since they are outside this directory.
     """
-    with cli_detection_mocks() as mock:
-        yield mock
-
-
-@pytest.fixture(autouse=True)
-def fast_retry_sleep(monkeypatch):
-    """Patch asyncio.sleep to be instant for all runner unit tests.
-
-    Prevents real waiting during the retry backoff loop. Tests in
-    tests/unit/test_process.py (timeout tests) are unaffected since
-    they are outside this directory.
-    """
-
-    async def instant_sleep(_: float) -> None:
-        pass
-
-    monkeypatch.setattr("asyncio.sleep", instant_sleep)

--- a/tests/unit/runners/test_base.py
+++ b/tests/unit/runners/test_base.py
@@ -24,16 +24,16 @@ from tests.fixtures import create_mock_process, make_agent_response, make_prompt
 class ConcreteRunner(AbstractRunner):
     """Test implementation of AbstractRunner for testing Template Method pattern."""
 
-    def __init__(self) -> None:
-        """Initialize test runner."""
-        super().__init__()
+    AGENT_NAME = "test"
 
     def build_command(self, request: PromptRequest) -> list[str]:
         """Build test command."""
         return ["test-cli", "-p", request.prompt]
 
     def parse_output(self, stdout: str, stderr: str) -> AgentResponse:
-        """Parse test output."""
+        """Parse test output. Raises ParseError for empty stdout (like real runners)."""
+        if not stdout.strip():
+            raise ParseError("No output from test-cli", raw_output=stdout)
         return AgentResponse(
             agent="test",
             output=stdout.strip(),
@@ -161,7 +161,11 @@ class TestAbstractRunner:
 
     @patch("nexus_mcp.process.asyncio.create_subprocess_exec")
     async def test_run_includes_stdout_in_subprocess_error(self, mock_exec, runner):
-        """SubprocessError raised on non-zero exit should carry stdout."""
+        """SubprocessError raised on non-zero exit (after failed recovery) should carry stdout.
+
+        Patches parse_output to raise ParseError so recovery fails and the generic
+        SubprocessError (raised by _execute) carries the original stdout value.
+        """
         error_json = '{"error": {"code": 429, "message": "Rate limit exceeded"}}'
         mock_exec.return_value = create_mock_process(
             stdout=error_json,
@@ -170,7 +174,10 @@ class TestAbstractRunner:
         )
         request = make_prompt_request()
 
-        with pytest.raises(SubprocessError) as exc_info:
+        with (
+            patch.object(runner, "parse_output", side_effect=ParseError("forced failure")),
+            pytest.raises(SubprocessError) as exc_info,
+        ):
             await runner.run(request)
 
         assert exc_info.value.stdout == error_json

--- a/tests/unit/runners/test_codex.py
+++ b/tests/unit/runners/test_codex.py
@@ -1,0 +1,287 @@
+# tests/unit/runners/test_codex.py
+"""Tests for CodexRunner.
+
+Tests verify:
+- CLINotFoundError when codex binary is absent
+- build_command() constructs correct argument list
+- build_command() respects model override and env default
+- build_command() uses custom CLI path
+- build_command() appends file_refs to prompt
+- execution mode flags: sandbox, yolo, default
+- parse_output() success and failure paths
+- error handling: _recover_from_error, _try_extract_error
+"""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from nexus_mcp.cli_detector import CLIInfo
+from nexus_mcp.exceptions import CLINotFoundError, ParseError, RetryableError, SubprocessError
+from nexus_mcp.runners.codex import CodexRunner
+from tests.fixtures import CODEX_NDJSON_RESPONSE, make_prompt_request
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_codex_runner() -> CodexRunner:
+    """Create a CodexRunner using the autouse cli_detection_mocks fixture."""
+    return CodexRunner()
+
+
+# ---------------------------------------------------------------------------
+# Initialisation
+# ---------------------------------------------------------------------------
+
+
+class TestCodexRunnerInit:
+    """Test CodexRunner initialisation and CLI detection."""
+
+    def test_cli_not_found_raises_error(self):
+        """CLINotFoundError raised when codex binary is absent."""
+        not_found = CLIInfo(found=False, path=None)
+        with (
+            patch("nexus_mcp.runners.base.detect_cli", return_value=not_found),
+            pytest.raises(CLINotFoundError) as exc_info,
+        ):
+            CodexRunner()
+        assert exc_info.value.cli_name == "codex"
+
+    def test_default_cli_path(self):
+        """Default cli_path is 'codex' when NEXUS_CODEX_PATH is not set."""
+        runner = make_codex_runner()
+        assert runner.cli_path == "codex"
+
+    def test_custom_cli_path_from_env(self):
+        """cli_path is taken from NEXUS_CODEX_PATH env var."""
+        with patch(
+            "nexus_mcp.runners.base.get_agent_env",
+            side_effect=lambda agent, key, **kw: "/custom/codex" if key == "PATH" else None,
+        ):
+            runner = make_codex_runner()
+        assert runner.cli_path == "/custom/codex"
+
+
+# ---------------------------------------------------------------------------
+# build_command
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCommand:
+    """Test CodexRunner.build_command() argument construction."""
+
+    def test_default_command_shape(self):
+        """Default command: [cli_path, 'exec', prompt, '--json']."""
+        runner = make_codex_runner()
+        cmd = runner.build_command(make_prompt_request(agent="codex", prompt="hello"))
+        assert cmd == ["codex", "exec", "hello", "--json"]
+
+    def test_model_override(self):
+        """request.model is forwarded as --model flag (adjacent to value)."""
+        runner = make_codex_runner()
+        cmd = runner.build_command(make_prompt_request(agent="codex", prompt="hi", model="o3"))
+        idx = cmd.index("--model")
+        assert cmd[idx + 1] == "o3"
+
+    def test_env_model_default(self):
+        """default_model from env is used when request.model is None."""
+        runner = make_codex_runner()
+        runner.default_model = "o1-mini"
+        cmd = runner.build_command(make_prompt_request(agent="codex", prompt="hi"))
+        idx = cmd.index("--model")
+        assert cmd[idx + 1] == "o1-mini"
+
+    def test_request_model_overrides_env_default(self):
+        """request.model takes precedence over default_model."""
+        runner = make_codex_runner()
+        runner.default_model = "o1-mini"
+        cmd = runner.build_command(make_prompt_request(agent="codex", prompt="hi", model="o3"))
+        idx = cmd.index("--model")
+        assert cmd[idx + 1] == "o3"
+        assert "o1-mini" not in cmd
+
+    def test_file_refs_appended_to_prompt(self):
+        """File references are appended to the prompt string."""
+        runner = make_codex_runner()
+        cmd = runner.build_command(
+            make_prompt_request(agent="codex", prompt="analyse", file_refs=["src/main.py"])
+        )
+        assert cmd[2].startswith("analyse")
+        assert "src/main.py" in cmd[2]
+
+    def test_sandbox_mode_adds_flags(self):
+        """execution_mode='sandbox' adds --sandbox workspace-write."""
+        runner = make_codex_runner()
+        cmd = runner.build_command(
+            make_prompt_request(agent="codex", prompt="x", execution_mode="sandbox")
+        )
+        assert "--sandbox" in cmd
+        assert "workspace-write" in cmd
+
+    def test_yolo_mode_adds_flag(self):
+        """execution_mode='yolo' adds --yolo flag."""
+        runner = make_codex_runner()
+        cmd = runner.build_command(
+            make_prompt_request(agent="codex", prompt="x", execution_mode="yolo")
+        )
+        assert "--yolo" in cmd
+
+    def test_default_mode_no_extra_flags(self):
+        """execution_mode='default' adds no extra approve flags."""
+        runner = make_codex_runner()
+        cmd = runner.build_command(
+            make_prompt_request(agent="codex", prompt="x", execution_mode="default")
+        )
+        assert "--sandbox" not in cmd
+        assert "--yolo" not in cmd
+
+    def test_build_command_model_with_yolo(self):
+        """model + yolo: --model appears before --yolo in the command."""
+        runner = make_codex_runner()
+        cmd = runner.build_command(
+            make_prompt_request(agent="codex", prompt="x", model="o3", execution_mode="yolo")
+        )
+        assert "--model" in cmd
+        assert "o3" in cmd
+        assert "--yolo" in cmd
+        assert cmd.index("--model") < cmd.index("--yolo")
+
+    def test_build_command_model_with_sandbox(self):
+        """model + sandbox: --model appears before --sandbox in the command."""
+        runner = make_codex_runner()
+        cmd = runner.build_command(
+            make_prompt_request(agent="codex", prompt="x", model="o3", execution_mode="sandbox")
+        )
+        assert "--model" in cmd
+        assert "o3" in cmd
+        assert "--sandbox" in cmd
+        assert "workspace-write" in cmd
+        assert cmd.index("--model") < cmd.index("--sandbox")
+
+
+# ---------------------------------------------------------------------------
+# parse_output
+# ---------------------------------------------------------------------------
+
+
+class TestParseOutput:
+    """Test CodexRunner.parse_output()."""
+
+    def test_success_single_message(self):
+        """Valid NDJSON with single agent_message → AgentResponse."""
+        runner = make_codex_runner()
+        result = runner.parse_output(CODEX_NDJSON_RESPONSE, "")
+        assert result.agent == "codex"
+        assert result.output == "pong"
+        assert result.raw_output == CODEX_NDJSON_RESPONSE
+
+    def test_multiple_items_joined(self):
+        """Multiple agent_message events are joined with \\n\\n."""
+
+        def event(text: str) -> str:
+            return json.dumps(
+                {"type": "item.completed", "item": {"type": "agent_message", "text": text}}
+            )
+
+        ndjson = "\n".join([event("part1"), event("part2")])
+        runner = make_codex_runner()
+        result = runner.parse_output(ndjson, "")
+        assert result.output == "part1\n\npart2"
+
+    def test_empty_stdout_raises_parse_error(self):
+        """Empty stdout → ParseError (no agent_message events found)."""
+        runner = make_codex_runner()
+        with pytest.raises(ParseError):
+            runner.parse_output("", "")
+
+    def test_no_agent_message_raises_parse_error(self):
+        """NDJSON with no agent_message events → ParseError."""
+        ndjson = '{"type": "thread.started"}\n{"type": "turn.completed"}'
+        runner = make_codex_runner()
+        with pytest.raises(ParseError):
+            runner.parse_output(ndjson, "")
+
+    def test_empty_text_field_falls_back_to_content_blocks(self):
+        """agent_message with empty text field falls back to content block list."""
+        event = json.dumps(
+            {
+                "type": "item.completed",
+                "item": {
+                    "type": "agent_message",
+                    "content": [{"text": "from content block"}],
+                },
+            }
+        )
+        runner = make_codex_runner()
+        result = runner.parse_output(event, "")
+        assert result.output == "from content block"
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+class TestErrorHandling:
+    """Test CodexRunner._recover_from_error and _try_extract_error."""
+
+    def test_no_json_in_stderr_or_stdout_returns_none(self):
+        """No structured error JSON → _recover_from_error returns None."""
+        runner = make_codex_runner()
+        result = runner._recover_from_error("not json", "also not json", 1)
+        assert result is None
+
+    def test_valid_ndjson_on_error_returns_recovered_response(self):
+        """Valid NDJSON in stdout on non-zero exit → recovered AgentResponse."""
+        runner = make_codex_runner()
+        result = runner._recover_from_error(CODEX_NDJSON_RESPONSE, "", 1)
+        assert result is not None
+        assert result.output == "pong"
+        assert result.metadata.get("recovered_from_error") is True
+
+    @pytest.mark.parametrize("code", [429, 503])
+    def test_retryable_error_codes_raise_retryable_error(self, code: int):
+        """Error codes 429 and 503 in stderr JSON → RetryableError."""
+        stderr = json.dumps({"error": {"code": code, "message": "transient error"}})
+        runner = make_codex_runner()
+        with pytest.raises(RetryableError):
+            runner._try_extract_error("", stderr, 1)
+
+    @pytest.mark.parametrize("code", ["429", "503"])
+    def test_retryable_string_error_codes_raise_retryable_error(self, code: str):
+        """String error codes '429' and '503' in stderr JSON → RetryableError (coerced)."""
+        stderr = json.dumps({"error": {"code": code, "message": "transient error"}})
+        runner = make_codex_runner()
+        with pytest.raises(RetryableError):
+            runner._try_extract_error("", stderr, 1)
+
+    def test_non_retryable_error_code_raises_subprocess_error(self):
+        """Non-retryable error code in stderr JSON → SubprocessError (not RetryableError)."""
+        stderr = json.dumps({"error": {"code": 401, "message": "unauthorized"}})
+        runner = make_codex_runner()
+        with pytest.raises(SubprocessError) as exc_info:
+            runner._try_extract_error("", stderr, 1)
+        assert not isinstance(exc_info.value, RetryableError)
+
+    def test_malformed_json_in_stderr_returns_none(self):
+        """Truncated/malformed JSON in stderr → _try_extract_error returns without raising."""
+        stderr = '{"error": {"code": 429, "message": "truncated...'
+        runner = make_codex_runner()
+        # Should not raise — malformed JSON falls through silently
+        result = runner._recover_from_error("", stderr, 1)
+        assert result is None
+
+    @patch("nexus_mcp.process.asyncio.create_subprocess_exec")
+    async def test_nonzero_returncode_raises_subprocess_error(self, mock_exec):
+        """Non-zero exit with no recoverable content → SubprocessError raised by run()."""
+        from tests.fixtures import create_mock_process
+
+        mock_exec.return_value = create_mock_process(
+            stdout="", stderr="something went wrong", returncode=1
+        )
+        runner = make_codex_runner()
+        with pytest.raises(SubprocessError):
+            await runner.run(make_prompt_request(agent="codex", prompt="x"))

--- a/tests/unit/runners/test_factory.py
+++ b/tests/unit/runners/test_factory.py
@@ -4,7 +4,7 @@
 Tests verify:
 - create("gemini") → GeminiRunner instance
 - create("unknown") → UnsupportedAgentError
-- list_agents() → ["gemini"]
+- list_agents() → ["codex", "gemini"]
 - create() returns cached instance for same agent
 - clear_cache() forces fresh instance on next create()
 """
@@ -12,6 +12,7 @@ Tests verify:
 import pytest
 
 from nexus_mcp.exceptions import UnsupportedAgentError
+from nexus_mcp.runners.codex import CodexRunner
 from nexus_mcp.runners.factory import RunnerFactory
 from nexus_mcp.runners.gemini import GeminiRunner
 
@@ -24,6 +25,12 @@ class TestRunnerFactory:
         runner = RunnerFactory.create("gemini")
 
         assert isinstance(runner, GeminiRunner)
+
+    def test_create_codex_runner(self):
+        """create("codex") should return CodexRunner instance."""
+        runner = RunnerFactory.create("codex")
+
+        assert isinstance(runner, CodexRunner)
 
     def test_create_unknown_agent_raises_error(self):
         """create("unknown") should raise UnsupportedAgentError."""
@@ -42,7 +49,7 @@ class TestRunnerFactory:
         """list_agents() should return list of supported agent names."""
         agents = RunnerFactory.list_agents()
 
-        assert agents == ["gemini"]
+        assert agents == ["codex", "gemini"]
 
     def test_create_returns_cached_instance(self):
         """create() should return the same cached instance for the same agent."""
@@ -59,14 +66,6 @@ class TestRunnerFactory:
 
         assert runner1 is not runner2  # Different instances after cache clear
         assert isinstance(runner2, GeminiRunner)
-
-    def test_create_caches_by_agent_name(self):
-        """Cache key is the agent name; same name returns same object."""
-        runner_a = RunnerFactory.create("gemini")
-        runner_b = RunnerFactory.create("gemini")
-
-        assert runner_a is runner_b
-        assert isinstance(runner_a, GeminiRunner)
 
     def test_list_agents_returns_sorted_order(self):
         """list_agents() should return agents in sorted (alphabetical) order."""

--- a/tests/unit/runners/test_gemini.py
+++ b/tests/unit/runners/test_gemini.py
@@ -252,8 +252,8 @@ class TestGeminiRunnerCLIDetection:
     def test_omits_json_if_not_supported(self):
         """With old version, JSON flag should be absent."""
         with (
-            patch("nexus_mcp.runners.gemini.detect_cli") as mock_detect,
-            patch("nexus_mcp.runners.gemini.get_cli_version", return_value="0.5.0"),
+            patch("nexus_mcp.runners.base.detect_cli") as mock_detect,
+            patch("nexus_mcp.runners.base.get_cli_version", return_value="0.5.0"),
         ):
             mock_detect.return_value = CLIInfo(found=True, path="/usr/bin/gemini")
             runner = GeminiRunner()

--- a/tests/unit/test_cli_detector.py
+++ b/tests/unit/test_cli_detector.py
@@ -99,6 +99,9 @@ class TestParseVersion:
         assert parse_version("Gemini CLI v0.12.0", cli="gemini") == "0.12.0"
 
     def test_parse_version_codex(self):
+        assert parse_version("codex-cli 0.107.0", cli="codex") == "0.107.0"
+
+    def test_parse_version_codex_version_format(self):
         assert parse_version("codex version 1.2.3", cli="codex") == "1.2.3"
 
     def test_parse_version_claude(self):

--- a/tests/unit/test_extension_points.py
+++ b/tests/unit/test_extension_points.py
@@ -70,6 +70,8 @@ class TestChunkExtensionPoint:
         from nexus_mcp.runners.base import AbstractRunner
 
         class ChunkableRunner(AbstractRunner):
+            AGENT_NAME = "test"
+
             def build_command(self, request: PromptRequest) -> list[str]:
                 return ["echo"]
 

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -6,7 +6,7 @@ Tests verify:
 - extract_last_json_array(): bracket-depth array extraction, returns first dict element
 """
 
-from nexus_mcp.parser import extract_last_json_array, extract_last_json_object
+from nexus_mcp.parser import extract_last_json_array, extract_last_json_object, parse_ndjson_events
 
 
 class TestExtractLastJsonObject:
@@ -118,3 +118,94 @@ class TestExtractLastJsonArray:
         text = '[{"first": 1}]\nsome text\n[{"second": 2}]'
         result = extract_last_json_array(text)
         assert result == {"second": 2}
+
+
+class TestParseNdjsonEvents:
+    """Test parse_ndjson_events() extracts text from Codex NDJSON output."""
+
+    def test_empty_input_returns_none(self):
+        """Empty string yields no events → None."""
+        assert parse_ndjson_events("") is None
+
+    def test_single_item_text_field(self):
+        """Single agent_message event with direct text field."""
+        line = '{"type": "item.completed", "item": {"type": "agent_message", "text": "pong"}}'
+        assert parse_ndjson_events(line) == "pong"
+
+    def test_multiple_items_joined_with_double_newline(self):
+        """Multiple agent_message events are joined with \\n\\n."""
+        ndjson = "\n".join(
+            [
+                '{"type": "item.completed", "item": {"type": "agent_message", "text": "first"}}',
+                '{"type": "item.completed", "item": {"type": "agent_message", "text": "second"}}',
+            ]
+        )
+        assert parse_ndjson_events(ndjson) == "first\n\nsecond"
+
+    def test_content_list_fallback(self):
+        """Uses content[*].text when direct text field is absent."""
+        line = (
+            '{"type": "item.completed", "item": {'
+            '"type": "agent_message", "content": [{"text": "from content"}]}}'
+        )
+        assert parse_ndjson_events(line) == "from content"
+
+    def test_non_agent_message_events_skipped(self):
+        """Events with item.type != agent_message are silently ignored."""
+        ndjson = "\n".join(
+            [
+                '{"type": "thread.started", "thread_id": "t1"}',
+                '{"type": "item.completed", "item": {"type": "tool_call", "text": "skip me"}}',
+                '{"type": "item.completed", "item": {"type": "agent_message", "text": "keep"}}',
+            ]
+        )
+        assert parse_ndjson_events(ndjson) == "keep"
+
+    def test_non_json_lines_skipped(self):
+        """Non-JSON lines are skipped without error."""
+        ndjson = "\n".join(
+            [
+                "not json at all",
+                '{"type": "item.completed", "item": {"type": "agent_message", "text": "ok"}}',
+            ]
+        )
+        assert parse_ndjson_events(ndjson) == "ok"
+
+    def test_blank_lines_skipped(self):
+        """Blank / whitespace-only lines are ignored."""
+        ndjson = "\n".join(
+            [
+                "",
+                '{"type": "item.completed", "item": {"type": "agent_message", "text": "hi"}}',
+                "   ",
+            ]
+        )
+        assert parse_ndjson_events(ndjson) == "hi"
+
+    def test_trailing_newline_handled(self):
+        """Trailing newline in stdout doesn't produce an empty part."""
+        ndjson = '{"type": "item.completed", "item": {"type": "agent_message", "text": "hi"}}\n'
+        assert parse_ndjson_events(ndjson) == "hi"
+
+    def test_lifecycle_events_with_no_agent_message_return_none(self):
+        """Status/lifecycle-only event stream with no agent_message → None."""
+        ndjson = "\n".join(
+            [
+                '{"type": "thread.started"}',
+                '{"type": "turn.completed"}',
+            ]
+        )
+        assert parse_ndjson_events(ndjson) is None
+
+    def test_partial_success_error_and_message(self):
+        """Stream with an error event followed by a valid agent_message → message text.
+
+        Error events (type='error') are not item.completed events, so they are
+        silently dropped by the filter guard. The agent_message is still returned.
+        """
+        error_event = '{"type": "error", "message": "something went wrong"}'
+        message_event = (
+            '{"type": "item.completed", "item": {"type": "agent_message", "text": "ok"}}'
+        )
+        ndjson = "\n".join([error_event, message_event])
+        assert parse_ndjson_events(ndjson) == "ok"

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -211,7 +211,7 @@ class TestListAgents:
     def test_list_agents_returns_supported_agents(self):
         """list_agents returns exactly the supported agent names."""
         agents = list_agents()
-        assert agents == ["gemini"]
+        assert agents == ["codex", "gemini"]
 
 
 class TestAssignLabels:

--- a/tests/unit/test_server_codex_pipeline.py
+++ b/tests/unit/test_server_codex_pipeline.py
@@ -1,0 +1,126 @@
+# tests/unit/test_server_codex_pipeline.py
+"""Pipeline integration tests: server tools → RunnerFactory → CodexRunner → subprocess.
+
+Mocks only at asyncio.create_subprocess_exec — all layers above run for real:
+    prompt()/batch_prompt() → RunnerFactory → CodexRunner → build_command
+        → run_subprocess → [MOCK] → parse_output
+"""
+
+import json
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from nexus_mcp.server import prompt
+from tests.fixtures import CODEX_NDJSON_RESPONSE, create_mock_process
+
+
+def _codex_ndjson(text: str) -> str:
+    """Build a minimal Codex NDJSON response with one agent_message event."""
+    return json.dumps(
+        {
+            "type": "item.completed",
+            "item": {"type": "agent_message", "text": text},
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# prompt() → CodexRunner pipeline
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("mock_cli_detection")
+class TestPromptCodexPipeline:
+    """Full prompt() → CodexRunner pipeline tests.
+
+    Mocks only asyncio.create_subprocess_exec. Everything above runs for real:
+        prompt() → RunnerFactory.create("codex") → CodexRunner
+            → build_command() → run_subprocess() → [MOCK] → parse_output()
+    """
+
+    async def test_success_returns_parsed_output(self, mock_subprocess, progress):
+        """Full success path: subprocess returns valid NDJSON → output text returned."""
+        mock_subprocess.return_value = create_mock_process(stdout=CODEX_NDJSON_RESPONSE)
+
+        result = await prompt("codex", "ping", progress=progress)
+
+        assert result == "pong"
+        assert mock_subprocess.call_count == 1
+        args = list(mock_subprocess.call_args.args)
+        assert "exec" in args
+        assert "--json" in args
+
+    async def test_model_reaches_subprocess_args(self, mock_subprocess, progress):
+        """model parameter is forwarded as --model flag in the subprocess command."""
+        mock_subprocess.return_value = create_mock_process(stdout=CODEX_NDJSON_RESPONSE)
+
+        await prompt("codex", "test", progress=progress, model="o3")
+
+        args = list(mock_subprocess.call_args.args)
+        assert "--model" in args
+        assert "o3" in args
+
+    async def test_sandbox_mode_reaches_subprocess_args(self, mock_subprocess, progress):
+        """execution_mode='sandbox' adds --sandbox workspace-write to subprocess args."""
+        mock_subprocess.return_value = create_mock_process(stdout=CODEX_NDJSON_RESPONSE)
+
+        await prompt("codex", "test", progress=progress, execution_mode="sandbox")
+
+        args = list(mock_subprocess.call_args.args)
+        assert "--sandbox" in args
+        assert "workspace-write" in args
+        assert "--yolo" not in args
+
+    async def test_yolo_mode_reaches_subprocess_args(self, mock_subprocess, progress):
+        """execution_mode='yolo' adds --yolo to subprocess args."""
+        mock_subprocess.return_value = create_mock_process(stdout=CODEX_NDJSON_RESPONSE)
+
+        await prompt("codex", "test", progress=progress, execution_mode="yolo")
+
+        args = list(mock_subprocess.call_args.args)
+        assert "--yolo" in args
+
+    async def test_empty_stdout_raises_tool_error(self, mock_subprocess, progress):
+        """Empty stdout (no agent_message events) → ParseError → ToolError."""
+        mock_subprocess.return_value = create_mock_process(stdout="", returncode=0)
+
+        with pytest.raises(ToolError, match=r"\[ParseError\]"):
+            await prompt("codex", "test", progress=progress)
+
+    async def test_recovery_from_nonzero_exit_with_valid_ndjson(self, mock_subprocess, progress):
+        """Non-zero exit with valid NDJSON → recovery path → output returned."""
+        mock_subprocess.return_value = create_mock_process(
+            stdout=CODEX_NDJSON_RESPONSE, returncode=1
+        )
+
+        result = await prompt("codex", "test", progress=progress)
+
+        assert result == "pong"
+
+    async def test_429_retries_then_succeeds(self, mock_subprocess, progress, fast_retry_sleep):
+        """HTTP 429 in stderr triggers retry; second attempt succeeds."""
+        error_stderr = json.dumps({"error": {"code": 429, "message": "rate limited"}})
+        mock_subprocess.side_effect = [
+            create_mock_process(stdout="", stderr=error_stderr, returncode=1),
+            create_mock_process(stdout=CODEX_NDJSON_RESPONSE),
+        ]
+
+        result = await prompt("codex", "test", progress=progress, max_retries=2)
+
+        assert result == "pong"
+        assert mock_subprocess.call_count == 2
+
+    async def test_multiple_agent_messages_joined(self, mock_subprocess, progress):
+        """Multiple agent_message events are joined with \\n\\n in the output."""
+        ndjson = "\n".join(
+            [
+                _codex_ndjson("part1"),
+                _codex_ndjson("part2"),
+            ]
+        )
+        mock_subprocess.return_value = create_mock_process(stdout=ndjson)
+
+        result = await prompt("codex", "test", progress=progress)
+
+        assert result == "part1\n\npart2"


### PR DESCRIPTION
Implement CodexRunner to execute and parse output from the Codex CLI using its NDJSON format. This includes adding a specialized NDJSON parser and updating the CLI detector to support Codex versioning.

Refactor the AbstractRunner base class to centralize CLI detection, versioning, and error recovery logic, which simplifies individual runner implementations and improves consistency across agents.