### PR TITLE
ci: add attestation permissions to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,7 @@ jobs:
       url: https://test.pypi.org/p/nexus-mcp
     permissions:
       id-token: write
+      attestations: write
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v8
@@ -100,6 +101,7 @@ jobs:
       url: https://pypi.org/p/nexus-mcp
     permissions:
       id-token: write
+      attestations: write
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v8


### PR DESCRIPTION
Enable the `attestations: write` permission to support artifact attestation when publishing to PyPI and TestPyPI.