### PR TITLE
feat(runners): add Claude Code CLI runner

### DIFF
--- a/src/nexus_mcp/parser.py
+++ b/src/nexus_mcp/parser.py
@@ -125,6 +125,37 @@ def parse_ndjson_events(stdout: str) -> str | None:
     return "\n\n".join(parts) if parts else None
 
 
+def extract_last_json_list(text: str) -> list[Any] | None:
+    """Find and parse the last JSON array in text, returning the full list.
+
+    Unlike extract_last_json_array() which returns only the first dict element,
+    this returns the entire parsed list — needed by ClaudeRunner to iterate
+    all conversation elements and find the result.
+
+    Returns None for empty arrays (same contract as extract_last_json_array).
+
+    Args:
+        text: String that may contain a JSON array, possibly mixed with other content.
+
+    Returns:
+        Parsed list if a non-empty JSON array is found, None otherwise.
+    """
+    if not text:
+        return None
+
+    search_end = len(text)
+    while True:
+        span = _find_balanced_span(text, "[", "]", search_end)
+        if span is None:
+            return None
+        start, last_close = span
+        with contextlib.suppress(json.JSONDecodeError, ValueError, RecursionError):
+            parsed = json.loads(text[start : last_close + 1])
+            if isinstance(parsed, list) and parsed:
+                return parsed
+        search_end = last_close
+
+
 def extract_last_json_array(text: str) -> dict[str, Any] | None:
     """Find and parse the last JSON array in a multi-line string, returning its first element.
 

--- a/src/nexus_mcp/runners/claude.py
+++ b/src/nexus_mcp/runners/claude.py
@@ -1,0 +1,264 @@
+# src/nexus_mcp/runners/claude.py
+"""Claude Code CLI runner implementation.
+
+Executes Anthropic's Claude Code CLI with JSON output format.
+
+Command format:
+    claude -p "<prompt>" --output-format json [--model <model>]
+    [--dangerously-skip-permissions]
+
+Expected JSON response (array of conversation elements):
+    [
+      {
+        "type": "assistant",
+        "message": {"role": "assistant", "content": [{"type": "text", "text": "..."}]},
+        "cost_usd": 0.001,
+        "duration_ms": 1234
+      },
+      {
+        "type": "result",
+        "result": "response text",
+        "session_id": "sess-abc123",
+        "cost_usd": 0.005,
+        "duration_ms": 5678,
+        "num_turns": 1
+      }
+    ]
+
+Note: Claude Code has no sandbox concept. execution_mode="sandbox" maps to default
+(no extra flags), maintaining the safe-by-default principle.
+"""
+
+import contextlib
+import json
+import logging
+from typing import Any
+
+from nexus_mcp.exceptions import ParseError, RetryableError, SubprocessError
+from nexus_mcp.parser import extract_last_json_list, extract_last_json_object
+from nexus_mcp.runners.base import AbstractRunner
+from nexus_mcp.types import AgentResponse, PromptRequest
+
+logger = logging.getLogger(__name__)
+
+
+class ClaudeRunner(AbstractRunner):
+    """Runner for Claude Code CLI.
+
+    Builds commands in format:
+        claude -p <prompt> --output-format json [options]
+
+    Parses JSON array responses, extracting text from the result element.
+
+    Note: Claude Code has no sandbox concept. execution_mode="sandbox" maps
+    to default (no extra flags), matching the safe-by-default principle.
+    """
+
+    AGENT_NAME = "claude"
+
+    def build_command(self, request: PromptRequest) -> list[str]:
+        """Build Claude Code CLI command from request.
+
+        Args:
+            request: PromptRequest with prompt, model, execution_mode, file_refs.
+
+        Returns:
+            Command list: [cli_path, "-p", <prompt>, "--output-format", "json", ...]
+
+        Command structure:
+            1. Base: {cli_path} -p <prompt> --output-format json
+            2. Add --model <model> (request.model > env default > CLI default)
+            3. Add --dangerously-skip-permissions if execution_mode == "yolo"
+            4. sandbox maps to default (no extra flags)
+        """
+        command = [self.cli_path, "-p", self._build_prompt(request), "--output-format", "json"]
+
+        model = request.model or self.default_model
+        if model:
+            command.extend(["--model", model])
+
+        match request.execution_mode:
+            case "sandbox":
+                logger.debug("Claude Code has no sandbox mode; using default (safe) mode")
+            case "yolo":
+                command.append("--dangerously-skip-permissions")
+            case _:
+                pass  # default: no extra flags
+
+        return command
+
+    def parse_output(self, stdout: str, stderr: str) -> AgentResponse:
+        """Parse Claude Code CLI JSON array output into AgentResponse.
+
+        Args:
+            stdout: JSON array output from Claude Code CLI.
+            stderr: Standard error output (not used for parsing).
+
+        Returns:
+            AgentResponse with:
+                - agent: "claude"
+                - output: Stripped result text
+                - raw_output: Original stdout
+                - metadata: cost_usd, duration_ms, num_turns, session_id (when present)
+
+        Raises:
+            ParseError: If output is not a valid JSON array, contains no result
+                        or assistant elements, or the result field is not a string.
+        """
+        # Fast path: clean JSON
+        try:
+            data = json.loads(stdout)
+        except json.JSONDecodeError:
+            # Fallback: extract array from noisy stdout (log lines before JSON)
+            data = extract_last_json_list(stdout)
+            if data is None:
+                # Also try single-object fallback for noisy stdout
+                obj = extract_last_json_object(stdout)
+                if obj is not None:
+                    data = [obj]
+                else:
+                    raise ParseError("Invalid JSON from Claude CLI", raw_output=stdout) from None
+
+        # Newer Claude CLI versions return a single object instead of an array
+        if isinstance(data, dict):
+            data = [data]
+        elif not isinstance(data, list):
+            raise ParseError("Expected JSON object or array from Claude CLI", raw_output=stdout)
+
+        # Find last "result" element (primary extraction path)
+        result_text, metadata = self._extract_result(data, stdout)
+        if result_text is None:
+            # Fallback: extract from last assistant message content blocks
+            result_text, metadata = self._extract_assistant_text(data)
+
+        if result_text is None:
+            raise ParseError("No result or assistant text in Claude CLI output", raw_output=stdout)
+
+        return AgentResponse(
+            agent=self.AGENT_NAME,
+            output=result_text.strip(),
+            raw_output=stdout,
+            metadata=metadata,
+        )
+
+    def _extract_result(
+        self, data: list[Any], raw_output: str = ""
+    ) -> tuple[str | None, dict[str, Any]]:
+        """Extract text and metadata from the last 'result' element.
+
+        Checks is_error to surface error responses rather than treating
+        them as successful output.
+
+        Args:
+            data: Parsed JSON array from Claude CLI.
+            raw_output: Original stdout for ParseError context.
+
+        Returns:
+            (result_text, metadata) tuple. result_text is None if no result element found.
+
+        Raises:
+            ParseError: If result element found but result field is not a string,
+                        or if is_error is True (error response from Claude).
+        """
+        for element in reversed(data):
+            if not isinstance(element, dict) or element.get("type") != "result":
+                continue
+            if element.get("is_error"):
+                error_msg = element.get("result", "unknown error")
+                raise ParseError(
+                    f"Claude CLI returned an error result: {error_msg}",
+                    raw_output=raw_output,
+                )
+            result = element.get("result")
+            if not isinstance(result, str):
+                raise ParseError(
+                    f"Expected string 'result', got {type(result).__name__}",
+                    raw_output=str(element),
+                )
+            metadata: dict[str, Any] = {}
+            for key in ("cost_usd", "duration_ms", "num_turns", "session_id"):
+                if key in element:
+                    metadata[key] = element[key]
+            return result, metadata
+        return None, {}
+
+    def _extract_assistant_text(self, data: list[Any]) -> tuple[str | None, dict[str, Any]]:
+        """Fallback: extract text and metadata from the last assistant message content blocks.
+
+        Args:
+            data: Parsed JSON array from Claude CLI.
+
+        Returns:
+            (text, metadata) tuple. text is None if no assistant element with content found.
+        """
+        for element in reversed(data):
+            if not isinstance(element, dict) or element.get("type") != "assistant":
+                continue
+            message = element.get("message", {})
+            content = message.get("content", []) if isinstance(message, dict) else []
+            parts: list[str] = []
+            if isinstance(content, list):
+                for block in content:
+                    if isinstance(block, dict):
+                        text = block.get("text")
+                        if isinstance(text, str):
+                            parts.append(text)
+            if parts:
+                metadata: dict[str, Any] = {}
+                for key in ("cost_usd", "duration_ms"):
+                    if key in element:
+                        metadata[key] = element[key]
+                return "\n\n".join(parts), metadata
+        return None, {}
+
+    def _try_extract_error(
+        self,
+        stdout: str,
+        stderr: str,
+        returncode: int,
+        command: list[str] | None = None,
+    ) -> None:
+        """Extract and raise a structured API error from stderr or stdout JSON.
+
+        Args:
+            stdout: Subprocess stdout to inspect as fallback.
+            stderr: Subprocess stderr inspected first.
+            returncode: Exit code (passed through to SubprocessError).
+            command: The CLI command that was run (passed through to SubprocessError).
+
+        Raises:
+            RetryableError: If error code is 429 or 503.
+            SubprocessError: If stderr or stdout contains a non-retryable error object.
+        """
+        data = None
+        for source in (stderr, stdout):
+            candidate = extract_last_json_object(source)
+            if candidate and isinstance(candidate.get("error"), dict):
+                data = candidate
+                break
+        if data is None:
+            return
+
+        error = data["error"]
+
+        code = error.get("code", "unknown")
+        if isinstance(code, str):
+            with contextlib.suppress(ValueError):
+                code = int(code)
+        message = error.get("message", "unknown error")
+        error_msg = f"Claude API error {code}: {message}"
+        if isinstance(code, int) and code in self._RETRYABLE_CODES:
+            raise RetryableError(
+                error_msg,
+                stderr=stderr,
+                stdout=stdout,
+                returncode=returncode,
+                command=command,
+            )
+        raise SubprocessError(
+            error_msg,
+            stderr=stderr,
+            stdout=stdout,
+            returncode=returncode,
+            command=command,
+        )

--- a/src/nexus_mcp/runners/factory.py
+++ b/src/nexus_mcp/runners/factory.py
@@ -12,6 +12,7 @@ Usage:
 
 from nexus_mcp.exceptions import UnsupportedAgentError
 from nexus_mcp.runners.base import AbstractRunner
+from nexus_mcp.runners.claude import ClaudeRunner
 from nexus_mcp.runners.codex import CodexRunner
 from nexus_mcp.runners.gemini import GeminiRunner
 
@@ -29,6 +30,7 @@ class RunnerFactory:
     """
 
     _REGISTRY: dict[str, type[AbstractRunner]] = {
+        ClaudeRunner.AGENT_NAME: ClaudeRunner,
         CodexRunner.AGENT_NAME: CodexRunner,
         GeminiRunner.AGENT_NAME: GeminiRunner,
     }
@@ -86,6 +88,6 @@ class RunnerFactory:
             Sorted list of agent names that can be passed to create().
 
         Example:
-            RunnerFactory.list_agents()  # → ["gemini"]
+            RunnerFactory.list_agents()  # → ["claude", "codex", "gemini"]
         """
         return sorted(cls._REGISTRY)

--- a/src/nexus_mcp/types.py
+++ b/src/nexus_mcp/types.py
@@ -36,6 +36,7 @@ class PromptRequest(BaseModel):
     )
     max_retries: int | None = Field(
         default=None,
+        ge=1,
         description="Max retry attempts for transient errors (None uses NEXUS_RETRY_MAX_ATTEMPTS)",
     )
 
@@ -72,7 +73,7 @@ class AgentTask(BaseModel):
     context: dict[str, Any] = Field(default_factory=dict)
     execution_mode: ExecutionMode | None = None  # None = use session preference or "default"
     model: str | None = None
-    max_retries: int | None = None
+    max_retries: int | None = Field(default=None, ge=1)
 
     @field_validator("agent", "prompt")
     @classmethod

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -38,12 +38,14 @@ async def mcp_client():
     exits via CancelledError (a FastMCP limitation), causing subsequent
     Client(mcp) connections to skip Docket initialization.
     """
-    async with Client(mcp) as client:
-        yield client
-    # WORKAROUND: FastMCP _lifespan_result_set stays True after CancelledError,
-    # causing subsequent Client(mcp) connections to skip Docket initialization.
-    # Remove when upstream fixes lifespan state cleanup on CancelledError.
-    mcp._lifespan_result_set = False
+    try:
+        async with Client(mcp) as client:
+            yield client
+    finally:
+        # WORKAROUND: FastMCP _lifespan_result_set stays True after CancelledError,
+        # causing subsequent Client(mcp) connections to skip Docket initialization.
+        # Remove when upstream fixes lifespan state cleanup on CancelledError.
+        mcp._lifespan_result_set = False
 
 
 @pytest.fixture

--- a/tests/e2e/test_mcp_protocol.py
+++ b/tests/e2e/test_mcp_protocol.py
@@ -89,7 +89,7 @@ class TestListAgentsProtocol:
         """call_tool('list_agents') returns all supported agents through JSON-RPC."""
         result = await mcp_client.call_tool("list_agents", {})
         assert result.is_error is False
-        assert result.data == ["codex", "gemini"]
+        assert result.data == ["claude", "codex", "gemini"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -48,7 +48,37 @@ CODEX_NDJSON_RESPONSE = "\n".join(
     ]
 )
 
-# Phase 7: Add CLAUDE_JSON_RESPONSE when implementing ClaudeCodeRunner.
+
+def claude_json(
+    result_text: str,
+    cost_usd: float = 0.005,
+    duration_ms: int = 5000,
+    num_turns: int = 1,
+) -> str:
+    """Build a Claude Code CLI JSON response string."""
+    data = [
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": result_text}],
+            },
+            "cost_usd": round(cost_usd * 0.2, 4),
+            "duration_ms": duration_ms // 2,
+        },
+        {
+            "type": "result",
+            "result": result_text,
+            "session_id": "test-session-id",
+            "cost_usd": cost_usd,
+            "duration_ms": duration_ms,
+            "num_turns": num_turns,
+        },
+    ]
+    return json.dumps(data)
+
+
+CLAUDE_JSON_RESPONSE = claude_json("test output")
 
 # ---------------------------------------------------------------------------
 # Integration test constants

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -9,6 +9,7 @@ import shutil
 
 import pytest
 
+from nexus_mcp.runners.claude import ClaudeRunner
 from nexus_mcp.runners.codex import CodexRunner
 from nexus_mcp.runners.gemini import GeminiRunner
 
@@ -55,5 +56,34 @@ def codex_runner(codex_cli_available: str) -> CodexRunner:  # noqa: ARG001
 
     Fresh instance per test to avoid state leakage between tests.
     Depends on codex_cli_available to skip if CLI is absent.
+
+    Uses gpt-5.2 as the default model because the Codex CLI's built-in
+    default (gpt-5.3-codex) is not supported on standard ChatGPT accounts,
+    and o4-mini is no longer supported on ChatGPT-authenticated accounts.
     """
-    return CodexRunner()
+    runner = CodexRunner()
+    runner.default_model = "gpt-5.2"
+    return runner
+
+
+@pytest.fixture(scope="session")
+def claude_cli_available() -> str:
+    """Skip all dependent tests if Claude CLI is not installed.
+
+    Returns:
+        Full path to the claude binary.
+    """
+    path = shutil.which("claude")
+    if path is None:
+        pytest.skip("Claude CLI not found in PATH — install to run integration tests")
+    return path  # type: ignore[return-value]
+
+
+@pytest.fixture
+def claude_runner(claude_cli_available: str) -> ClaudeRunner:  # noqa: ARG001
+    """Create a real ClaudeRunner per test.
+
+    Fresh instance per test to avoid state leakage between tests.
+    Depends on claude_cli_available to skip if CLI is absent.
+    """
+    return ClaudeRunner()

--- a/tests/integration/test_claude_runner.py
+++ b/tests/integration/test_claude_runner.py
@@ -1,0 +1,33 @@
+# tests/integration/test_claude_runner.py
+"""Integration tests for ClaudeRunner against the real Claude CLI.
+
+These tests require the `claude` CLI binary installed and available in PATH.
+They are automatically skipped when the CLI is absent (via the
+claude_cli_available fixture in conftest.py).
+
+Run with:
+    uv run pytest -m integration -v
+"""
+
+import pytest
+
+from nexus_mcp.runners.claude import ClaudeRunner
+from tests.fixtures import PING_PROMPT, make_prompt_request
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+async def test_claude_runner_real_invocation(claude_runner: ClaudeRunner) -> None:
+    """ClaudeRunner.run() against real CLI returns non-empty output with correct agent."""
+    response = await claude_runner.run(make_prompt_request(agent="claude", prompt=PING_PROMPT))
+    assert response.output
+    assert response.agent == "claude"
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+async def test_claude_runner_metadata_present(claude_runner: ClaudeRunner) -> None:
+    """Real Claude CLI response includes cost_usd and duration_ms metadata."""
+    response = await claude_runner.run(make_prompt_request(agent="claude", prompt=PING_PROMPT))
+    # Metadata may include cost/timing fields from the JSON response
+    assert isinstance(response.metadata, dict)

--- a/tests/unit/runners/test_claude.py
+++ b/tests/unit/runners/test_claude.py
@@ -1,0 +1,423 @@
+# tests/unit/runners/test_claude.py
+"""Tests for ClaudeRunner.
+
+Tests verify:
+- CLINotFoundError when claude binary is absent
+- build_command() constructs correct argument list
+- build_command() respects model override and env default
+- build_command() uses custom CLI path
+- build_command() appends file_refs to prompt
+- execution mode flags: yolo, sandbox (maps to default), default
+- parse_output() success and failure paths, including is_error handling
+- error handling: _recover_from_error, _try_extract_error
+"""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from nexus_mcp.cli_detector import CLIInfo
+from nexus_mcp.exceptions import CLINotFoundError, ParseError, RetryableError, SubprocessError
+from nexus_mcp.runners.claude import ClaudeRunner
+from tests.fixtures import (
+    CLAUDE_JSON_RESPONSE,
+    claude_json,
+    create_mock_process,
+    make_prompt_request,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_claude_runner() -> ClaudeRunner:
+    """Create a ClaudeRunner using the autouse cli_detection_mocks fixture."""
+    return ClaudeRunner()
+
+
+# ---------------------------------------------------------------------------
+# Initialisation
+# ---------------------------------------------------------------------------
+
+
+class TestClaudeRunnerInit:
+    """Test ClaudeRunner initialisation and CLI detection."""
+
+    def test_cli_not_found_raises_error(self):
+        """CLINotFoundError raised when claude binary is absent."""
+        not_found = CLIInfo(found=False, path=None)
+        with (
+            patch("nexus_mcp.runners.base.detect_cli", return_value=not_found),
+            pytest.raises(CLINotFoundError) as exc_info,
+        ):
+            ClaudeRunner()
+        assert exc_info.value.cli_name == "claude"
+
+    def test_default_cli_path(self):
+        """Default cli_path is 'claude' when NEXUS_CLAUDE_PATH is not set."""
+        runner = make_claude_runner()
+        assert runner.cli_path == "claude"
+
+    def test_custom_cli_path_from_env(self):
+        """cli_path is taken from NEXUS_CLAUDE_PATH env var."""
+        with patch(
+            "nexus_mcp.runners.base.get_agent_env",
+            side_effect=lambda agent, key, **kw: "/custom/claude" if key == "PATH" else None,
+        ):
+            runner = make_claude_runner()
+        assert runner.cli_path == "/custom/claude"
+
+
+# ---------------------------------------------------------------------------
+# build_command
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCommand:
+    """Test ClaudeRunner.build_command() argument construction."""
+
+    def test_default_command_shape(self):
+        """Default command: [cli_path, '-p', prompt, '--output-format', 'json']."""
+        runner = make_claude_runner()
+        cmd = runner.build_command(make_prompt_request(agent="claude", prompt="hello"))
+        assert cmd == ["claude", "-p", "hello", "--output-format", "json"]
+
+    def test_model_override(self):
+        """request.model is forwarded as --model flag."""
+        runner = make_claude_runner()
+        cmd = runner.build_command(
+            make_prompt_request(agent="claude", prompt="hi", model="claude-sonnet-4-6")
+        )
+        idx = cmd.index("--model")
+        assert cmd[idx + 1] == "claude-sonnet-4-6"
+
+    def test_env_model_default(self):
+        """default_model from env is used when request.model is None."""
+        runner = make_claude_runner()
+        runner.default_model = "claude-haiku-4-5-20251001"
+        cmd = runner.build_command(make_prompt_request(agent="claude", prompt="hi"))
+        idx = cmd.index("--model")
+        assert cmd[idx + 1] == "claude-haiku-4-5-20251001"
+
+    def test_request_model_overrides_env_default(self):
+        """request.model takes precedence over default_model."""
+        runner = make_claude_runner()
+        runner.default_model = "claude-haiku-4-5-20251001"
+        cmd = runner.build_command(
+            make_prompt_request(agent="claude", prompt="hi", model="claude-sonnet-4-6")
+        )
+        idx = cmd.index("--model")
+        assert cmd[idx + 1] == "claude-sonnet-4-6"
+        assert "claude-haiku-4-5-20251001" not in cmd
+
+    def test_file_refs_appended_to_prompt(self):
+        """File references are appended to the prompt string."""
+        runner = make_claude_runner()
+        cmd = runner.build_command(
+            make_prompt_request(agent="claude", prompt="analyse", file_refs=["src/main.py"])
+        )
+        assert cmd[2].startswith("analyse")
+        assert "src/main.py" in cmd[2]
+
+    def test_yolo_mode_adds_flag(self):
+        """execution_mode='yolo' adds --dangerously-skip-permissions flag."""
+        runner = make_claude_runner()
+        cmd = runner.build_command(
+            make_prompt_request(agent="claude", prompt="x", execution_mode="yolo")
+        )
+        assert "--dangerously-skip-permissions" in cmd
+
+    def test_sandbox_mode_maps_to_default(self):
+        """execution_mode='sandbox' adds no extra flags (Claude has no sandbox)."""
+        runner = make_claude_runner()
+        cmd = runner.build_command(
+            make_prompt_request(agent="claude", prompt="x", execution_mode="sandbox")
+        )
+        assert "--dangerously-skip-permissions" not in cmd
+
+    def test_default_mode_no_extra_flags(self):
+        """execution_mode='default' adds no extra approve flags."""
+        runner = make_claude_runner()
+        cmd = runner.build_command(
+            make_prompt_request(agent="claude", prompt="x", execution_mode="default")
+        )
+        assert "--dangerously-skip-permissions" not in cmd
+
+    def test_all_options_combined(self):
+        """model + yolo + file_refs: all options present in correct order."""
+        runner = make_claude_runner()
+        cmd = runner.build_command(
+            make_prompt_request(
+                agent="claude",
+                prompt="analyse",
+                model="claude-sonnet-4-6",
+                execution_mode="yolo",
+                file_refs=["src/main.py"],
+            )
+        )
+        assert "--model" in cmd
+        assert "claude-sonnet-4-6" in cmd
+        assert "--dangerously-skip-permissions" in cmd
+        assert cmd.index("--model") < cmd.index("--dangerously-skip-permissions")
+
+
+# ---------------------------------------------------------------------------
+# parse_output
+# ---------------------------------------------------------------------------
+
+
+class TestParseOutput:
+    """Test ClaudeRunner.parse_output()."""
+
+    def test_success_extracts_result_text(self):
+        """Valid Claude JSON array → AgentResponse with correct output."""
+        runner = make_claude_runner()
+        result = runner.parse_output(CLAUDE_JSON_RESPONSE, "")
+        assert result.agent == "claude"
+        assert result.output == "test output"
+        assert result.raw_output == CLAUDE_JSON_RESPONSE
+
+    def test_metadata_extracted(self):
+        """Metadata contains cost_usd, duration_ms, num_turns, session_id."""
+        runner = make_claude_runner()
+        result = runner.parse_output(CLAUDE_JSON_RESPONSE, "")
+        assert "cost_usd" in result.metadata
+        assert "duration_ms" in result.metadata
+        assert "num_turns" in result.metadata
+        assert "session_id" in result.metadata
+
+    def test_fallback_to_assistant_content(self):
+        """JSON array with no 'result' type but has 'assistant' → extracts from content."""
+        data = [
+            {
+                "type": "assistant",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "assistant response"}],
+                },
+                "cost_usd": 0.001,
+                "duration_ms": 1000,
+            }
+        ]
+        runner = make_claude_runner()
+        result = runner.parse_output(json.dumps(data), "")
+        assert result.output == "assistant response"
+
+    def test_fallback_metadata_from_assistant(self):
+        """Assistant-fallback path includes cost_usd and duration_ms in metadata."""
+        data = [
+            {
+                "type": "assistant",
+                "message": {"role": "assistant", "content": [{"type": "text", "text": "hi"}]},
+                "cost_usd": 0.002,
+                "duration_ms": 2000,
+            }
+        ]
+        runner = make_claude_runner()
+        result = runner.parse_output(json.dumps(data), "")
+        assert result.metadata.get("cost_usd") == 0.002
+        assert result.metadata.get("duration_ms") == 2000
+
+    def test_whitespace_stripping(self):
+        """Output text is stripped of leading/trailing whitespace."""
+        data = [{"type": "result", "result": "  hello world  "}]
+        runner = make_claude_runner()
+        result = runner.parse_output(json.dumps(data), "")
+        assert result.output == "hello world"
+
+    def test_empty_stdout_raises_parse_error(self):
+        """Empty string → ParseError."""
+        runner = make_claude_runner()
+        with pytest.raises(ParseError):
+            runner.parse_output("", "")
+
+    def test_invalid_json_raises_parse_error(self):
+        """Non-JSON string → ParseError."""
+        runner = make_claude_runner()
+        with pytest.raises(ParseError):
+            runner.parse_output("this is not json", "")
+
+    def test_no_result_or_assistant_raises_parse_error(self):
+        """Array with only irrelevant types → ParseError."""
+        data = [{"type": "system"}, {"type": "tool_result"}]
+        runner = make_claude_runner()
+        with pytest.raises(ParseError):
+            runner.parse_output(json.dumps(data), "")
+
+    def test_non_string_result_raises_parse_error(self):
+        """Non-string 'result' field → ParseError (explicit type check)."""
+        data = [{"type": "result", "result": 42}]
+        runner = make_claude_runner()
+        with pytest.raises(ParseError):
+            runner.parse_output(json.dumps(data), "")
+
+    def test_noisy_stdout_with_log_prefix(self):
+        """Log lines before JSON array still parses via extract_last_json_list fallback."""
+        noisy = "(node:1234) DeprecationWarning: some warning\nLoaded credentials.\n" + claude_json(
+            "pong from noisy output"
+        )
+        runner = make_claude_runner()
+        result = runner.parse_output(noisy, "")
+        assert result.output == "pong from noisy output"
+
+    def test_non_list_json_raises_parse_error(self):
+        """Non-object, non-array JSON (e.g. bare integer) → ParseError."""
+        runner = make_claude_runner()
+        with pytest.raises(ParseError):
+            runner.parse_output("42", "")
+
+    def test_single_object_result_parsed(self):
+        """Single JSON object with type=result → parsed correctly (new CLI format)."""
+        stdout = json.dumps(
+            {
+                "type": "result",
+                "subtype": "success",
+                "is_error": False,
+                "result": "pong",
+                "duration_ms": 2492,
+                "session_id": "sess-new",
+                "cost_usd": 0.003,
+                "num_turns": 1,
+            }
+        )
+        runner = make_claude_runner()
+        result = runner.parse_output(stdout, "")
+        assert result.output == "pong"
+        assert result.agent == "claude"
+
+    def test_single_object_with_metadata(self):
+        """Single JSON object → metadata fields extracted correctly."""
+        stdout = json.dumps(
+            {
+                "type": "result",
+                "subtype": "success",
+                "is_error": False,
+                "result": "hello",
+                "duration_ms": 1234,
+                "session_id": "sess-abc",
+                "cost_usd": 0.001,
+                "num_turns": 2,
+            }
+        )
+        runner = make_claude_runner()
+        result = runner.parse_output(stdout, "")
+        assert result.metadata.get("duration_ms") == 1234
+        assert result.metadata.get("session_id") == "sess-abc"
+        assert result.metadata.get("cost_usd") == 0.001
+        assert result.metadata.get("num_turns") == 2
+
+    def test_is_error_result_raises_parse_error(self):
+        """Result element with is_error=true → ParseError (not successful output)."""
+        data = [{"type": "result", "is_error": True, "result": "Error: something failed"}]
+        runner = make_claude_runner()
+        with pytest.raises(ParseError, match="error result"):
+            runner.parse_output(json.dumps(data), "")
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+class TestErrorHandling:
+    """Test ClaudeRunner._recover_from_error and _try_extract_error."""
+
+    def test_no_json_in_stderr_or_stdout_returns_none(self):
+        """No structured error JSON → _recover_from_error returns None."""
+        runner = make_claude_runner()
+        result = runner._recover_from_error("not json", "also not json", 1)
+        assert result is None
+
+    def test_valid_claude_json_on_error_returns_recovered_response(self):
+        """Valid Claude JSON array in stdout on non-zero exit → recovered AgentResponse."""
+        runner = make_claude_runner()
+        result = runner._recover_from_error(CLAUDE_JSON_RESPONSE, "", 1)
+        assert result is not None
+        assert result.output == "test output"
+        assert result.metadata.get("recovered_from_error") is True
+
+    def test_malformed_stderr_falls_through(self):
+        """Truncated/malformed JSON in stderr → _try_extract_error returns without raising."""
+        stderr = '{"error": {"code": 429, "message": "truncated...'
+        runner = make_claude_runner()
+        result = runner._recover_from_error("", stderr, 1)
+        assert result is None
+
+    def test_error_json_in_stdout_fallback(self):
+        """Empty stderr, error JSON in stdout → extracts and raises SubprocessError."""
+        stdout = json.dumps({"error": {"code": 401, "message": "unauthorized"}})
+        runner = make_claude_runner()
+        with pytest.raises(SubprocessError):
+            runner._try_extract_error(stdout, "", 1)
+
+
+class TestRetryableErrors:
+    """Test ClaudeRunner retryable error classification."""
+
+    @pytest.mark.parametrize("code", [429, 503])
+    def test_retryable_error_codes_raise_retryable_error(self, code: int):
+        """Error codes 429 and 503 in stderr JSON → RetryableError."""
+        stderr = json.dumps({"error": {"code": code, "message": "transient error"}})
+        runner = make_claude_runner()
+        with pytest.raises(RetryableError):
+            runner._try_extract_error("", stderr, 1)
+
+    @pytest.mark.parametrize("code", ["429", "503"])
+    def test_retryable_string_error_codes_raise_retryable_error(self, code: str):
+        """String error codes '429' and '503' → RetryableError (coerced to int)."""
+        stderr = json.dumps({"error": {"code": code, "message": "transient error"}})
+        runner = make_claude_runner()
+        with pytest.raises(RetryableError):
+            runner._try_extract_error("", stderr, 1)
+
+    def test_non_retryable_error_code_raises_subprocess_error(self):
+        """Non-retryable error code → SubprocessError (not RetryableError)."""
+        stderr = json.dumps({"error": {"code": 401, "message": "unauthorized"}})
+        runner = make_claude_runner()
+        with pytest.raises(SubprocessError) as exc_info:
+            runner._try_extract_error("", stderr, 1)
+        assert not isinstance(exc_info.value, RetryableError)
+
+    @patch("nexus_mcp.process.asyncio.create_subprocess_exec")
+    async def test_retry_integration_429_then_success(self, mock_exec):
+        """Full run() with 429 on first call, success on second → await_count == 2."""
+        error_stderr = json.dumps({"error": {"code": 429, "message": "rate limited"}})
+        mock_exec.side_effect = [
+            create_mock_process(stdout="", stderr=error_stderr, returncode=1),
+            create_mock_process(stdout=CLAUDE_JSON_RESPONSE, returncode=0),
+        ]
+        runner = make_claude_runner()
+        result = await runner.run(make_prompt_request(agent="claude", prompt="x"))
+        assert result.output == "test output"
+        assert mock_exec.await_count == 2
+
+    @patch("nexus_mcp.process.asyncio.create_subprocess_exec")
+    async def test_nonzero_returncode_raises_subprocess_error(self, mock_exec):
+        """Non-zero exit with no recoverable content → SubprocessError raised by run()."""
+        mock_exec.return_value = create_mock_process(
+            stdout="", stderr="something went wrong", returncode=1
+        )
+        runner = make_claude_runner()
+        with pytest.raises(SubprocessError):
+            await runner.run(make_prompt_request(agent="claude", prompt="x"))
+
+    def test_stderr_json_without_error_key_falls_through_to_stdout(self):
+        """stderr JSON without 'error' key → stdout inspected; 429 in stdout → RetryableError."""
+        stderr = json.dumps({"debug": "diagnostic info"})
+        stdout = json.dumps({"error": {"code": 429, "message": "rate limited"}})
+        runner = make_claude_runner()
+        with pytest.raises(RetryableError):
+            runner._try_extract_error(stdout, stderr, 1)
+
+    @patch("nexus_mcp.process.asyncio.create_subprocess_exec")
+    async def test_retry_all_attempts_exhausted(self, mock_exec):
+        """All 3 attempts return 429 → RetryableError raised; subprocess called 3 times."""
+        error_stderr = json.dumps({"error": {"code": 429, "message": "rate limited"}})
+        mock_exec.return_value = create_mock_process(stdout="", stderr=error_stderr, returncode=1)
+        runner = make_claude_runner()
+        request = make_prompt_request(agent="claude", prompt="x", max_retries=3)
+        with pytest.raises(RetryableError):
+            await runner.run(request)
+        assert mock_exec.await_count == 3

--- a/tests/unit/runners/test_factory.py
+++ b/tests/unit/runners/test_factory.py
@@ -3,8 +3,10 @@
 
 Tests verify:
 - create("gemini") → GeminiRunner instance
+- create("codex") → CodexRunner instance
+- create("claude") → ClaudeRunner instance
 - create("unknown") → UnsupportedAgentError
-- list_agents() → ["codex", "gemini"]
+- list_agents() → ["claude", "codex", "gemini"]
 - create() returns cached instance for same agent
 - clear_cache() forces fresh instance on next create()
 """
@@ -12,6 +14,7 @@ Tests verify:
 import pytest
 
 from nexus_mcp.exceptions import UnsupportedAgentError
+from nexus_mcp.runners.claude import ClaudeRunner
 from nexus_mcp.runners.codex import CodexRunner
 from nexus_mcp.runners.factory import RunnerFactory
 from nexus_mcp.runners.gemini import GeminiRunner
@@ -45,11 +48,17 @@ class TestRunnerFactory:
         with pytest.raises(UnsupportedAgentError):
             RunnerFactory.create("Gemini")  # Capital G
 
+    def test_create_claude_runner(self):
+        """create("claude") should return ClaudeRunner instance."""
+        runner = RunnerFactory.create("claude")
+
+        assert isinstance(runner, ClaudeRunner)
+
     def test_list_agents_returns_supported_agents(self):
         """list_agents() should return list of supported agent names."""
         agents = RunnerFactory.list_agents()
 
-        assert agents == ["codex", "gemini"]
+        assert agents == ["claude", "codex", "gemini"]
 
     def test_create_returns_cached_instance(self):
         """create() should return the same cached instance for the same agent."""

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -4,9 +4,15 @@
 Tests verify:
 - extract_last_json_object(): brace-depth JSON extraction from mixed text
 - extract_last_json_array(): bracket-depth array extraction, returns first dict element
+- extract_last_json_list(): bracket-depth array extraction, returns full list
 """
 
-from nexus_mcp.parser import extract_last_json_array, extract_last_json_object, parse_ndjson_events
+from nexus_mcp.parser import (
+    extract_last_json_array,
+    extract_last_json_list,
+    extract_last_json_object,
+    parse_ndjson_events,
+)
 
 
 class TestExtractLastJsonObject:
@@ -118,6 +124,64 @@ class TestExtractLastJsonArray:
         text = '[{"first": 1}]\nsome text\n[{"second": 2}]'
         result = extract_last_json_array(text)
         assert result == {"second": 2}
+
+
+class TestExtractLastJsonList:
+    """Test extract_last_json_list() returns the full list from the last JSON array."""
+
+    def test_clean_input_returns_full_list(self):
+        """Clean JSON array → full list returned."""
+        text = '[{"type": "result", "result": "hello"}, {"type": "assistant"}]'
+        result = extract_last_json_list(text)
+        assert result == [{"type": "result", "result": "hello"}, {"type": "assistant"}]
+
+    def test_noisy_stdout_extracts_array(self):
+        """Log lines before JSON array are ignored; array extracted correctly."""
+        text = (
+            "(node:1234) Warning: some deprecation\n"
+            "Loaded credentials.\n"
+            '[{"type": "result", "result": "pong"}]'
+        )
+        result = extract_last_json_list(text)
+        assert result == [{"type": "result", "result": "pong"}]
+
+    def test_empty_string_returns_none(self):
+        """Empty string → None."""
+        result = extract_last_json_list("")
+        assert result is None
+
+    def test_no_brackets_returns_none(self):
+        """Text without brackets → None."""
+        result = extract_last_json_list('{"key": "value"}')
+        assert result is None
+
+    def test_invalid_json_returns_none(self):
+        """Brackets found but invalid JSON → None."""
+        result = extract_last_json_list("[not valid json}")
+        assert result is None
+
+    def test_non_dict_elements_returned_as_list(self):
+        """List of scalars returned as-is (no element-type filtering)."""
+        result = extract_last_json_list("[1, 2, 3]")
+        assert result == [1, 2, 3]
+
+    def test_empty_array_returns_none(self):
+        """Empty JSON array '[]' → None (same contract as extract_last_json_array)."""
+        result = extract_last_json_list("[]")
+        assert result is None
+
+    def test_returns_all_elements_not_just_first(self):
+        """Full list returned — not just the first dict like extract_last_json_array."""
+        text = '[{"a": 1}, {"b": 2}, {"c": 3}]'
+        result = extract_last_json_list(text)
+        assert result == [{"a": 1}, {"b": 2}, {"c": 3}]
+        assert len(result) == 3  # type: ignore[arg-type]
+
+    def test_picks_last_array_when_multiple_present(self):
+        """Returns the full last array when multiple arrays exist in text."""
+        text = '[{"first": 1}]\nsome text\n[{"second": 2}, {"third": 3}]'
+        result = extract_last_json_list(text)
+        assert result == [{"second": 2}, {"third": 3}]
 
 
 class TestParseNdjsonEvents:

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -212,7 +212,7 @@ class TestListAgents:
     def test_list_agents_returns_supported_agents(self):
         """list_agents returns exactly the supported agent names."""
         agents = list_agents()
-        assert agents == ["codex", "gemini"]
+        assert agents == ["claude", "codex", "gemini"]
 
 
 class TestAssignLabels:

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -224,6 +224,24 @@ def test_agent_task_max_retries_accepts_custom_value():
     assert task.max_retries == 2
 
 
+def test_prompt_request_max_retries_zero_fails():
+    """max_retries=0 is rejected (ge=1); would cause range(0) → unreachable assertion."""
+    with pytest.raises(ValidationError):
+        PromptRequest(agent="gemini", prompt="Hello", max_retries=0)
+
+
+def test_prompt_request_max_retries_negative_fails():
+    """Negative max_retries is rejected by ge=1 validator."""
+    with pytest.raises(ValidationError):
+        PromptRequest(agent="gemini", prompt="Hello", max_retries=-1)
+
+
+def test_agent_task_max_retries_zero_fails():
+    """AgentTask.max_retries=0 is rejected (ge=1)."""
+    with pytest.raises(ValidationError):
+        AgentTask(agent="gemini", prompt="Hello", max_retries=0)
+
+
 # ---------------------------------------------------------------------------
 # error_type field tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Implement the ClaudeRunner to interface with Anthropic's Claude Code CLI. This includes command building with support for YOLO and sandbox modes, robust JSON output parsing with fallback mechanisms for assistant content, and structured error handling for retryable API errors (429/503).

Additional changes:
- Add `extract_last_json_list` to the parser for handling JSON array responses.
- Enforce a minimum value of 1 for `max_retries` in `PromptRequest` and `AgentTask`.
- Register Claude in the `RunnerFactory` and update agent listing logic.
- Improve E2E test reliability by ensuring lifespan state cleanup in fixtures.
- Add comprehensive unit, integration, and protocol tests for the new runner.