### PR TITLE
ci: add actions read permission to security

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,6 +15,7 @@ concurrency:
 permissions:
   contents: read
   security-events: write
+  actions: read
 
 jobs:
   codeql:


### PR DESCRIPTION
This permission is required for the CodeQL analysis job to correctly access workflow metadata, addressing errors encountered during the security scanning process.