### PR TITLE
fix: harden config validation and error reporting

### DIFF
--- a/src/nexus_mcp/config.py
+++ b/src/nexus_mcp/config.py
@@ -23,9 +23,15 @@ def _get_int_env(env_var: str, default: str, label: str) -> int:
 def _get_float_env(env_var: str, default: str, label: str) -> float:
     raw = os.getenv(env_var, default)
     try:
-        return float(raw)
+        value = float(raw)
     except ValueError:
         raise ConfigurationError(f"Invalid {label} value: {raw!r}", config_key=env_var) from None
+    if not math.isfinite(value):
+        raise ConfigurationError(
+            f"{label.capitalize()} must be a finite number, got {value}",
+            config_key=env_var,
+        )
+    return value
 
 
 def get_global_output_limit() -> int:
@@ -35,12 +41,18 @@ def get_global_output_limit() -> int:
         Output limit in bytes (default: 50KB)
 
     Raises:
-        ConfigurationError: If env var value is not a valid integer
+        ConfigurationError: If env var value is not a valid integer or not positive
 
     Environment Variable:
         NEXUS_OUTPUT_LIMIT_BYTES: Max output size in bytes
     """
-    return _get_int_env("NEXUS_OUTPUT_LIMIT_BYTES", "50000", "output limit")
+    value = _get_int_env("NEXUS_OUTPUT_LIMIT_BYTES", "50000", "output limit")
+    if value <= 0:
+        raise ConfigurationError(
+            f"Output limit must be positive, got {value}",
+            config_key="NEXUS_OUTPUT_LIMIT_BYTES",
+        )
+    return value
 
 
 def get_global_timeout() -> int:
@@ -50,12 +62,18 @@ def get_global_timeout() -> int:
         Timeout in seconds (default: 600s = 10 minutes, matches process.py)
 
     Raises:
-        ConfigurationError: If env var value is not a valid integer
+        ConfigurationError: If env var value is not a valid integer or not positive
 
     Environment Variable:
         NEXUS_TIMEOUT_SECONDS: Subprocess timeout in seconds
     """
-    return _get_int_env("NEXUS_TIMEOUT_SECONDS", "600", "timeout")
+    value = _get_int_env("NEXUS_TIMEOUT_SECONDS", "600", "timeout")
+    if value <= 0:
+        raise ConfigurationError(
+            f"Timeout must be positive, got {value}",
+            config_key="NEXUS_TIMEOUT_SECONDS",
+        )
+    return value
 
 
 def get_retry_max_attempts() -> int:
@@ -65,12 +83,18 @@ def get_retry_max_attempts() -> int:
         Max retry attempts (default: 3)
 
     Raises:
-        ConfigurationError: If env var value is not a valid integer
+        ConfigurationError: If env var value is not a valid integer or not positive
 
     Environment Variable:
         NEXUS_RETRY_MAX_ATTEMPTS: Max number of attempts (including the first)
     """
-    return _get_int_env("NEXUS_RETRY_MAX_ATTEMPTS", "3", "retry max attempts")
+    value = _get_int_env("NEXUS_RETRY_MAX_ATTEMPTS", "3", "retry max attempts")
+    if value <= 0:
+        raise ConfigurationError(
+            f"Retry max attempts must be positive, got {value}",
+            config_key="NEXUS_RETRY_MAX_ATTEMPTS",
+        )
+    return value
 
 
 def get_retry_base_delay() -> float:
@@ -119,11 +143,6 @@ def get_tool_timeout() -> float | None:
             Set to 0 to disable. Must be finite and non-negative.
     """
     value = _get_float_env("NEXUS_TOOL_TIMEOUT_SECONDS", "900.0", "tool timeout")
-    if not math.isfinite(value):
-        raise ConfigurationError(
-            f"Tool timeout must be a finite number, got {value}",
-            config_key="NEXUS_TOOL_TIMEOUT_SECONDS",
-        )
     if value < 0:
         raise ConfigurationError(
             f"Tool timeout must be non-negative, got {value}",

--- a/src/nexus_mcp/parser.py
+++ b/src/nexus_mcp/parser.py
@@ -1,9 +1,9 @@
 # src/nexus_mcp/parser.py
-"""Generic JSON extraction utilities for CLI runner output parsing.
+"""JSON extraction utilities for CLI runner output parsing.
 
-Functions here operate on raw strings and have no coupling to any specific CLI agent.
-They handle the common pattern of extracting valid JSON from noisy stdout/stderr that
-may contain log lines, Node.js warnings, stack traces, or other non-JSON content.
+Most functions here operate on raw strings with no coupling to a specific CLI
+agent. The exception is parse_ndjson_events, which handles the Codex CLI's
+NDJSON event stream format.
 """
 
 import contextlib

--- a/src/nexus_mcp/process.py
+++ b/src/nexus_mcp/process.py
@@ -52,6 +52,7 @@ async def run_subprocess(command: list[str], timeout: float | None = 600.0) -> S
             raise SubprocessError(
                 f"Failed to decode subprocess output: {e}",
                 stderr=stderr_bytes.decode("utf-8", errors="replace"),
+                stdout=stdout_bytes.decode("utf-8", errors="replace"),
                 command=command,
             ) from None
 

--- a/src/nexus_mcp/types.py
+++ b/src/nexus_mcp/types.py
@@ -18,7 +18,7 @@ DEFAULT_MAX_CONCURRENCY = 3
 
 
 class PromptRequest(BaseModel):
-    agent: str
+    agent: str = Field(..., min_length=1)
     prompt: str = Field(..., min_length=1)
     context: dict[str, Any] = Field(default_factory=dict)
     execution_mode: ExecutionMode = Field(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -112,6 +112,16 @@ class TestGetRetryBaseDelay:
         assert exc_info.value.config_key == "NEXUS_RETRY_BASE_DELAY"
         assert "Invalid retry base delay value" in str(exc_info.value)
 
+    @patch.dict(os.environ, {"NEXUS_RETRY_BASE_DELAY": "inf"})
+    def test_inf_raises_configuration_error(self):
+        with pytest.raises(ConfigurationError, match="must be a finite number"):
+            get_retry_base_delay()
+
+    @patch.dict(os.environ, {"NEXUS_RETRY_BASE_DELAY": "nan"})
+    def test_nan_raises_configuration_error(self):
+        with pytest.raises(ConfigurationError, match="must be a finite number"):
+            get_retry_base_delay()
+
 
 class TestGetRetryMaxDelay:
     """Test get_retry_max_delay() function."""
@@ -132,6 +142,16 @@ class TestGetRetryMaxDelay:
             get_retry_max_delay()
         assert exc_info.value.config_key == "NEXUS_RETRY_MAX_DELAY"
         assert "Invalid retry max delay value" in str(exc_info.value)
+
+    @patch.dict(os.environ, {"NEXUS_RETRY_MAX_DELAY": "inf"})
+    def test_inf_raises_configuration_error(self):
+        with pytest.raises(ConfigurationError, match="must be a finite number"):
+            get_retry_max_delay()
+
+    @patch.dict(os.environ, {"NEXUS_RETRY_MAX_DELAY": "nan"})
+    def test_nan_raises_configuration_error(self):
+        with pytest.raises(ConfigurationError, match="must be a finite number"):
+            get_retry_max_delay()
 
 
 class TestGetToolTimeout:
@@ -192,18 +212,38 @@ class TestGetToolTimeout:
         assert "must be a finite number" in str(exc_info.value)
 
 
-class TestNegativeValueDocumentation:
-    """Bug-documenting tests: negative values accepted where validators are absent."""
+class TestPositiveValueValidation:
+    """Config functions reject non-positive values where semantically required."""
 
     @patch.dict(os.environ, {"NEXUS_OUTPUT_LIMIT_BYTES": "-1"})
-    def test_negative_output_limit_accepted(self):
-        """NEXUS_OUTPUT_LIMIT_BYTES=-1 returns -1 (no lower-bound validation)."""
-        assert get_global_output_limit() == -1
+    def test_negative_output_limit_rejected(self):
+        with pytest.raises(ConfigurationError):
+            get_global_output_limit()
+
+    @patch.dict(os.environ, {"NEXUS_OUTPUT_LIMIT_BYTES": "0"})
+    def test_zero_output_limit_rejected(self):
+        with pytest.raises(ConfigurationError):
+            get_global_output_limit()
 
     @patch.dict(os.environ, {"NEXUS_RETRY_MAX_ATTEMPTS": "-1"})
-    def test_negative_retry_max_attempts_accepted(self):
-        """NEXUS_RETRY_MAX_ATTEMPTS=-1 returns -1 (no lower-bound validation)."""
-        assert get_retry_max_attempts() == -1
+    def test_negative_retry_max_attempts_rejected(self):
+        with pytest.raises(ConfigurationError):
+            get_retry_max_attempts()
+
+    @patch.dict(os.environ, {"NEXUS_RETRY_MAX_ATTEMPTS": "0"})
+    def test_zero_retry_max_attempts_rejected(self):
+        with pytest.raises(ConfigurationError):
+            get_retry_max_attempts()
+
+    @patch.dict(os.environ, {"NEXUS_TIMEOUT_SECONDS": "-1"})
+    def test_negative_timeout_rejected(self):
+        with pytest.raises(ConfigurationError):
+            get_global_timeout()
+
+    @patch.dict(os.environ, {"NEXUS_TIMEOUT_SECONDS": "0"})
+    def test_zero_timeout_rejected(self):
+        with pytest.raises(ConfigurationError):
+            get_global_timeout()
 
 
 class TestGetCLIDetectionTimeout:

--- a/tests/unit/test_process.py
+++ b/tests/unit/test_process.py
@@ -40,6 +40,19 @@ async def test_run_subprocess_handles_unicode_errors(mock_exec):
 
 
 @patch("nexus_mcp.process.asyncio.create_subprocess_exec")
+async def test_unicode_error_preserves_decodable_stdout(mock_exec):
+    """When stderr has invalid UTF-8 but stdout is valid, stdout is preserved in the error."""
+    mock_exec.return_value = create_mock_process(
+        stdout_bytes=b"valid stdout",
+        stderr_bytes=b"\xff\xfe",  # Invalid UTF-8
+        returncode=0,
+    )
+    with pytest.raises(SubprocessError) as exc_info:
+        await run_subprocess(["cmd"])
+    assert exc_info.value.stdout == "valid stdout"
+
+
+@patch("nexus_mcp.process.asyncio.create_subprocess_exec")
 async def test_run_subprocess_handles_partial_output(mock_exec):
     """Handle subprocess killed mid-output (partial JSON)."""
     mock_exec.return_value = create_mock_process(

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -24,10 +24,10 @@ def test_prompt_request_empty_prompt_fails():
         PromptRequest(agent="gemini", prompt="")
 
 
-def test_prompt_request_empty_agent_accepted():
-    """Bug-documenting: PromptRequest(agent='') succeeds (no min_length validator on agent)."""
-    req = PromptRequest(agent="", prompt="hi")
-    assert req.agent == ""
+def test_prompt_request_empty_agent_rejected():
+    """Empty agent string is rejected by min_length=1."""
+    with pytest.raises(ValidationError):
+        PromptRequest(agent="", prompt="hi")
 
 
 def test_prompt_request_default_execution_mode():


### PR DESCRIPTION
- Reject non-positive values for timeouts, limits, and retry attempts
- Ensure float environment variables are finite numbers (not NaN/Inf)
- Require non-empty agent identifiers in PromptRequest via min_length
- Include stdout in SubprocessError when Unicode decoding fails
- Update docstrings and unit tests to reflect stricter constraints