### PR TITLE
fix: address codebase review findings (H2, M3, M4)

### DIFF
--- a/src/nexus_mcp/runners/base.py
+++ b/src/nexus_mcp/runners/base.py
@@ -22,7 +22,6 @@ import asyncio
 import contextlib
 import logging
 import random
-import tempfile
 from abc import ABC, abstractmethod
 from typing import Any, ClassVar, NoReturn, Protocol
 
@@ -221,13 +220,13 @@ class AbstractRunner(ABC):
         return computed
 
     def _apply_output_limit(self, response: AgentResponse) -> AgentResponse:
-        """Truncate output if exceeds limit, save full output to temp file.
+        """Truncate output if it exceeds the configured byte limit.
 
         Args:
             response: Original response from parse_output()
 
         Returns:
-            Response with truncated output if needed, metadata includes temp file path
+            Response with truncated output if needed; metadata includes original/truncated sizes.
         """
         limit = get_global_output_limit()
         output_bytes = response.output.encode("utf-8")
@@ -236,19 +235,8 @@ class AbstractRunner(ABC):
         if output_size <= limit:
             return response  # No truncation needed
 
-        # Save full output to temp file
-        with tempfile.NamedTemporaryFile(
-            mode="w",
-            encoding="utf-8",
-            delete=False,
-            prefix="nexus_mcp_output_",
-            suffix=".txt",
-        ) as temp_file:
-            temp_file.write(response.output)
-            temp_file_name = temp_file.name
-
-        # Reserve space for truncation message
-        suffix = "\n\n[Output truncated - see full output at temp file]"
+        # Reserve space for truncation message (computed with actual sizes)
+        suffix = f"\n\n[Output truncated: {output_size} bytes exceeds {limit} byte limit]"
         suffix_bytes = len(suffix.encode("utf-8"))
         content_limit = max(0, limit - suffix_bytes)
 
@@ -259,7 +247,6 @@ class AbstractRunner(ABC):
 
         return response.model_copy(update={"output": truncated_output}).with_metadata(
             truncated=True,
-            full_output_path=temp_file_name,
             original_size_bytes=output_size,
             truncated_size_bytes=len(truncated_output.encode("utf-8")),
         )

--- a/src/nexus_mcp/types.py
+++ b/src/nexus_mcp/types.py
@@ -15,11 +15,12 @@ class SessionPreferences(BaseModel):
 
 
 DEFAULT_MAX_CONCURRENCY = 3
+MAX_PROMPT_LENGTH = 131072  # 128KB character limit — conservative guard against ARG_MAX
 
 
 class PromptRequest(BaseModel):
     agent: str = Field(..., min_length=1)
-    prompt: str = Field(..., min_length=1)
+    prompt: str = Field(..., min_length=1, max_length=MAX_PROMPT_LENGTH)
     context: dict[str, Any] = Field(default_factory=dict)
     execution_mode: ExecutionMode = Field(
         default="default",
@@ -34,6 +35,17 @@ class PromptRequest(BaseModel):
         default_factory=list,
         description="Optional file paths for agent context (appended to prompt)",
     )
+
+    @field_validator("file_refs")
+    @classmethod
+    def no_control_chars_in_paths(cls, v: list[str]) -> list[str]:
+        for i, path in enumerate(v):
+            if any(c in path for c in "\x00\n\r"):
+                raise ValueError(
+                    f"file_refs[{i}] contains control characters (null/newline/carriage-return)"
+                )
+        return v
+
     max_retries: int | None = Field(
         default=None,
         ge=1,
@@ -67,20 +79,13 @@ class SubprocessResult(BaseModel):
 class AgentTask(BaseModel):
     """Per-task input for batch_prompt."""
 
-    agent: str
-    prompt: str
+    agent: str = Field(..., min_length=1)
+    prompt: str = Field(..., min_length=1, max_length=MAX_PROMPT_LENGTH)
     label: str | None = None
     context: dict[str, Any] = Field(default_factory=dict)
     execution_mode: ExecutionMode | None = None  # None = use session preference or "default"
     model: str | None = None
     max_retries: int | None = Field(default=None, ge=1)
-
-    @field_validator("agent", "prompt")
-    @classmethod
-    def must_be_non_empty(cls, v: str) -> str:
-        if not v:
-            raise ValueError("must not be empty")
-        return v
 
     def to_request(self) -> "PromptRequest":
         """Convert this task to a PromptRequest for runner execution."""

--- a/tests/unit/runners/test_base.py
+++ b/tests/unit/runners/test_base.py
@@ -125,7 +125,7 @@ class TestAbstractRunner:
 
     @patch("nexus_mcp.process.asyncio.create_subprocess_exec")
     async def test_runner_truncates_large_output(self, mock_exec, runner):
-        """Runner truncates output exceeding limit and saves to temp file."""
+        """Runner truncates output exceeding limit and records size metadata."""
         # Create 100KB output
         large_output = "x" * 100_000
         mock_exec.return_value = create_mock_process(stdout=large_output)
@@ -137,9 +137,7 @@ class TestAbstractRunner:
 
         # Output should be truncated
         assert len(response.output.encode("utf-8")) <= 50_000
-        # Metadata should include temp file path
         assert response.metadata.get("truncated") is True
-        assert "full_output_path" in response.metadata
         assert response.metadata.get("original_size_bytes") == 100_000
 
     @patch("nexus_mcp.process.asyncio.create_subprocess_exec")
@@ -447,7 +445,8 @@ class TestTruncationBehavior:
         with patch("nexus_mcp.config.get_global_output_limit", return_value=50_000):
             response = await runner.run(request)
 
-        assert response.output.endswith("\n\n[Output truncated - see full output at temp file]")
+        expected_suffix = "\n\n[Output truncated: 100000 bytes exceeds 50000 byte limit]"
+        assert response.output.endswith(expected_suffix)
 
     @patch("nexus_mcp.process.asyncio.create_subprocess_exec")
     async def test_truncation_at_exact_boundary(self, mock_exec, runner):

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -2,6 +2,7 @@ import pytest
 from pydantic import ValidationError
 
 from nexus_mcp.types import (
+    MAX_PROMPT_LENGTH,
     AgentResponse,
     AgentTask,
     AgentTaskResult,
@@ -108,6 +109,32 @@ def test_prompt_request_file_refs_must_be_strings():
             prompt="test",
             file_refs=["valid.py", 123, None],  # Invalid types
         )
+
+
+def test_file_refs_rejects_null_byte():
+    """file_refs rejects paths containing null bytes."""
+    with pytest.raises(ValidationError, match="control characters"):
+        PromptRequest(agent="gemini", prompt="test", file_refs=["/etc/\x00passwd"])
+
+
+def test_file_refs_rejects_newline():
+    """file_refs rejects paths containing newline characters."""
+    with pytest.raises(ValidationError, match="control characters"):
+        PromptRequest(agent="gemini", prompt="test", file_refs=["/etc\n/passwd"])
+
+
+def test_file_refs_rejects_carriage_return():
+    """file_refs rejects paths containing carriage return characters."""
+    with pytest.raises(ValidationError, match="control characters"):
+        PromptRequest(agent="gemini", prompt="test", file_refs=["foo\rbar"])
+
+
+def test_file_refs_accepts_normal_paths():
+    """file_refs accepts normal absolute and relative paths."""
+    req = PromptRequest(
+        agent="gemini", prompt="test", file_refs=["/home/user/file.py", "relative/path"]
+    )
+    assert req.file_refs == ["/home/user/file.py", "relative/path"]
 
 
 def test_agent_response_with_metadata_adds_keys():
@@ -246,6 +273,29 @@ def test_agent_task_max_retries_zero_fails():
     """AgentTask.max_retries=0 is rejected (ge=1)."""
     with pytest.raises(ValidationError):
         AgentTask(agent="gemini", prompt="Hello", max_retries=0)
+
+
+# ---------------------------------------------------------------------------
+# Prompt max_length tests (M4)
+# ---------------------------------------------------------------------------
+
+
+def test_prompt_request_rejects_oversized_prompt():
+    """PromptRequest rejects prompts exceeding MAX_PROMPT_LENGTH (128KB)."""
+    with pytest.raises(ValidationError):
+        PromptRequest(agent="gemini", prompt="x" * (MAX_PROMPT_LENGTH + 1))
+
+
+def test_agent_task_rejects_oversized_prompt():
+    """AgentTask rejects prompts exceeding MAX_PROMPT_LENGTH (128KB)."""
+    with pytest.raises(ValidationError):
+        AgentTask(agent="gemini", prompt="x" * (MAX_PROMPT_LENGTH + 1))
+
+
+def test_prompt_at_max_length_accepted():
+    """PromptRequest accepts a prompt exactly at MAX_PROMPT_LENGTH."""
+    req = PromptRequest(agent="gemini", prompt="x" * MAX_PROMPT_LENGTH)
+    assert len(req.prompt) == MAX_PROMPT_LENGTH
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
H2: reject control characters (null, newline, CR) in PromptRequest.file_refs via field_validator — prevents prompt injection through malformed paths.

M3: remove orphaned temp file creation from _apply_output_limit; replace static truncation suffix with dynamic "{N} bytes exceeds {limit} byte limit" message; drop full_output_path from metadata.

M4: add MAX_PROMPT_LENGTH = 131072 (128KB) guard on PromptRequest.prompt and AgentTask.prompt; replace must_be_non_empty validator on AgentTask with Field(min_length=1) constraints on agent and prompt fields.