### PR TITLE
feat(server): add session execution preferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ parallel rather than sequentially:
   spillover for outputs exceeding 50 KB
 - **Execution modes** — `default` (safe, no auto-approve), `yolo` (full auto-approve)
 - **CLI detection** — auto-detects binary path, version, and JSON output capability at startup
-- **Session preferences** — set defaults for execution mode and model once per session; subsequent calls inherit them without repeating parameters
+- **Session preferences** — set defaults for execution mode, model, max retries, output limit, and timeout once per session; subsequent calls inherit them without repeating parameters
 - **Tool timeouts** — configurable safety timeout (default 15 min) cancels long-running tool calls to prevent the server from blocking indefinitely
 - **Extensible** — implement `build_command` + `parse_output`, register in `RunnerFactory`
 
@@ -125,13 +125,14 @@ Runner discovery happens once per session; subsequent examples skip the `list_ru
 ```json
 {
   "execution_mode": "yolo",
-  "model": "gemini-2.5-flash"
+  "model": "gemini-2.5-flash",
+  "max_retries": 5
 }
 ```
 
 **Response:**
 ```
-Preferences set: {"execution_mode": "yolo", "model": "gemini-2.5-flash"}
+Preferences set: {"execution_mode": "yolo", "model": "gemini-2.5-flash", "max_retries": 5, "output_limit": null, "timeout": null}
 ```
 
 **Subsequent `prompt` and `batch_prompt` calls omit those fields — they inherit from the session:**
@@ -145,16 +146,16 @@ Preferences set: {"execution_mode": "yolo", "model": "gemini-2.5-flash"}
 
 The fallback chain is: **explicit parameter → session preference → system default**.
 To override for one call, pass the parameter directly — it takes precedence without changing the session.
-To clear a single preference, use `set_preferences` with the corresponding `clear_*` flag (e.g. `clear_model: true`).
+To clear a single preference, use `set_preferences` with the corresponding `clear_*` flag (e.g. `clear_execution_mode: true`, `clear_model: true`, `clear_max_retries: true`, `clear_output_limit: true`, `clear_timeout: true`).
 
 ### Managing Session Preferences
 
 | Operation | Tool | Notes |
 |-----------|------|-------|
-| Set one or both fields | `set_preferences` | Pass only the fields you want to change |
-| Read current values | `get_preferences` | Returns `{execution_mode, model}` with `null` for unset fields |
+| Set one or more fields | `set_preferences` | Pass only the fields you want to change |
+| Read current values | `get_preferences` | Returns `{execution_mode, model, max_retries, output_limit, timeout}` with `null` for unset fields |
 | Clear all fields | `clear_preferences` | Reverts to per-call defaults |
-| Clear one preference | `set_preferences` with `clear_model: true` or `clear_execution_mode: true` | Other preference is preserved |
+| Clear one preference | `set_preferences` with `clear_model: true`, `clear_execution_mode: true`, `clear_max_retries: true`, `clear_output_limit: true`, or `clear_timeout: true` | Other preferences are preserved |
 
 ### Parameter Reference
 
@@ -175,7 +176,9 @@ To clear a single preference, use `set_preferences` with the corresponding `clea
 | `context` | No | `{}` | Optional context metadata dict |
 | `execution_mode` | No | session pref or `"default"` | `"default"` or `"yolo"` |
 | `model` | No | session pref or CLI default | Model name override |
-| `max_retries` | No | env default | Max retry attempts for transient errors |
+| `max_retries` | No | session pref or env default | Max retry attempts for transient errors |
+| `output_limit` | No | session pref or env default | Max output bytes before temp-file spillover |
+| `timeout` | No | session pref or env default | Subprocess timeout in seconds |
 
 #### `prompt`
 
@@ -186,7 +189,9 @@ To clear a single preference, use `set_preferences` with the corresponding `clea
 | `context` | No | `{}` | Optional context metadata dict |
 | `execution_mode` | No | session pref or `"default"` | `"default"` or `"yolo"` |
 | `model` | No | session pref or CLI default | Model name override |
-| `max_retries` | No | env default | Max retry attempts for transient errors |
+| `max_retries` | No | session pref or env default | Max retry attempts for transient errors |
+| `output_limit` | No | session pref or env default | Max output bytes before temp-file spillover |
+| `timeout` | No | session pref or env default | Subprocess timeout in seconds |
 
 #### `list_runners`
 
@@ -198,12 +203,18 @@ No parameters. Returns a list of `RunnerInfo` objects with fields: `name`, `type
 |-----------|----------|---------|-------------|
 | `execution_mode` | No | — | `"default"` or `"yolo"` |
 | `model` | No | — | Model name (e.g. `"gemini-2.5-flash"`) |
+| `max_retries` | No | — | Max total attempts including the first (≥1; 1 means run once, no retries) |
+| `output_limit` | No | — | Max output bytes before temp-file spillover (≥1) |
+| `timeout` | No | — | Subprocess timeout in seconds (≥1) |
 | `clear_execution_mode` | No | `false` | Clear execution mode (takes precedence if `execution_mode` is also provided) |
 | `clear_model` | No | `false` | Clear model (takes precedence if `model` is also provided) |
+| `clear_max_retries` | No | `false` | Clear max retries (takes precedence if `max_retries` is also provided) |
+| `clear_output_limit` | No | `false` | Clear output limit (takes precedence if `output_limit` is also provided) |
+| `clear_timeout` | No | `false` | Clear timeout (takes precedence if `timeout` is also provided) |
 
 #### `get_preferences`
 
-No parameters. Returns a dict with `execution_mode` and `model` keys (`null` when unset).
+No parameters. Returns a dict with `execution_mode`, `model`, `max_retries`, `output_limit`, and `timeout` keys (`null` when unset).
 
 #### `clear_preferences`
 
@@ -219,7 +230,7 @@ poll for results, preventing MCP timeouts for long operations (e.g. YOLO mode: 2
 | `batch_prompt` | Yes | Fan out prompts to multiple runners in parallel; returns `MultiPromptResponse` |
 | `prompt` | Yes | Single-runner convenience wrapper; routes to `batch_prompt` |
 | `list_runners` | No | Returns structured metadata for each runner (provider, models, available, execution_modes, default_model) |
-| `set_preferences` | No | Set or selectively clear session defaults for execution mode and model |
+| `set_preferences` | No | Set or selectively clear session defaults for execution mode, model, max retries, output limit, and timeout |
 | `get_preferences` | No | Retrieve current session preferences |
 | `clear_preferences` | No | Reset all session preferences |
 
@@ -333,6 +344,7 @@ uv run python -m nexus_mcp
 | `NEXUS_RETRY_MAX_ATTEMPTS` | `3` | Max attempts including the first (set to 1 to disable retries) |
 | `NEXUS_RETRY_BASE_DELAY` | `2.0` | Base seconds for exponential backoff |
 | `NEXUS_RETRY_MAX_DELAY` | `60.0` | Maximum seconds to wait between retries |
+| `NEXUS_CLI_DETECTION_TIMEOUT` | `30` | Timeout in seconds for CLI binary version detection at startup |
 
 ### Agent-Specific Environment Variables
 

--- a/src/nexus_mcp/runners/base.py
+++ b/src/nexus_mcp/runners/base.py
@@ -175,7 +175,8 @@ class AbstractRunner(ABC):
         command = self.build_command(request)
 
         # Step 2: Execute subprocess
-        result = await run_subprocess(command, timeout=self.timeout)
+        effective_timeout = request.timeout if request.timeout is not None else self.timeout
+        result = await run_subprocess(command, timeout=effective_timeout)
 
         # Step 3: Error check with recovery attempt
         if result.returncode != 0:
@@ -183,7 +184,7 @@ class AbstractRunner(ABC):
                 result.stdout, result.stderr, result.returncode, command
             )
             if recovered:
-                return self._apply_output_limit(recovered)
+                return self._apply_output_limit(recovered, request)
             raise SubprocessError(
                 f"CLI command failed with exit code {result.returncode}",
                 stderr=result.stderr,
@@ -196,7 +197,7 @@ class AbstractRunner(ABC):
         response = self.parse_output(result.stdout, result.stderr)
 
         # Step 5: Apply output limiting
-        return self._apply_output_limit(response)
+        return self._apply_output_limit(response, request)
 
     def _compute_backoff(self, attempt: int, retry_after: float | None) -> float:
         """Compute exponential backoff delay with full jitter.
@@ -220,16 +221,19 @@ class AbstractRunner(ABC):
             return max(computed, retry_after)
         return computed
 
-    def _apply_output_limit(self, response: AgentResponse) -> AgentResponse:
+    def _apply_output_limit(self, response: AgentResponse, request: PromptRequest) -> AgentResponse:
         """Truncate output if it exceeds the configured byte limit.
 
         Args:
             response: Original response from parse_output()
+            request: Prompt request, checked for per-request output_limit override.
 
         Returns:
             Response with truncated output if needed; metadata includes original/truncated sizes.
         """
-        limit = get_global_output_limit()
+        limit = (
+            request.output_limit if request.output_limit is not None else get_global_output_limit()
+        )
         output_bytes = response.output.encode("utf-8")
         output_size = len(output_bytes)
 

--- a/src/nexus_mcp/server.py
+++ b/src/nexus_mcp/server.py
@@ -69,6 +69,12 @@ def _apply_preferences(task: AgentTask, prefs: SessionPreferences) -> AgentTask:
         updates["execution_mode"] = prefs.execution_mode or "default"
     if task.model is None and prefs.model is not None:
         updates["model"] = prefs.model
+    if task.max_retries is None and prefs.max_retries is not None:
+        updates["max_retries"] = prefs.max_retries
+    if task.output_limit is None and prefs.output_limit is not None:
+        updates["output_limit"] = prefs.output_limit
+    if task.timeout is None and prefs.timeout is not None:
+        updates["timeout"] = prefs.timeout
     if updates:
         return task.model_copy(update=updates)
     return task
@@ -195,6 +201,8 @@ async def prompt(
     execution_mode: ExecutionMode | None = None,
     model: str | None = None,
     max_retries: int | None = None,
+    output_limit: int | None = None,
+    timeout: int | None = None,
     ctx: Context | None = None,
 ) -> str:
     """Send a prompt to a CLI runner as a background task.
@@ -208,7 +216,9 @@ async def prompt(
         context: Optional context metadata
         execution_mode: 'default' (safe) or 'yolo'. None inherits session preference.
         model: Optional model name. None inherits session preference or uses CLI default.
-        max_retries: Max retry attempts for transient errors (None uses env default)
+        max_retries: Max retry attempts for transient errors (None inherits session preference).
+        output_limit: Max output bytes (None inherits session preference or uses env default).
+        timeout: Subprocess timeout seconds (None inherits session preference or uses env default).
         ctx: MCP context (auto-injected by FastMCP). None when called directly in tests.
 
     Returns:
@@ -219,6 +229,9 @@ async def prompt(
     session_mode = prefs.execution_mode or "default"
     resolved_mode = execution_mode if execution_mode is not None else session_mode
     resolved_model = model if model is not None else prefs.model
+    resolved_max_retries = max_retries if max_retries is not None else prefs.max_retries
+    resolved_output_limit = output_limit if output_limit is not None else prefs.output_limit
+    resolved_timeout = timeout if timeout is not None else prefs.timeout
 
     task = AgentTask(
         cli=cli,
@@ -226,7 +239,9 @@ async def prompt(
         context=context or {},
         execution_mode=resolved_mode,
         model=resolved_model,
-        max_retries=max_retries,
+        max_retries=resolved_max_retries,
+        output_limit=resolved_output_limit,
+        timeout=resolved_timeout,
     )
     result = await batch_prompt(tasks=[task], ctx=ctx)
     task_result = result.results[0]
@@ -277,8 +292,14 @@ def list_runners() -> list[RunnerInfo]:
 async def set_preferences(
     execution_mode: ExecutionMode | None = None,
     model: str | None = None,
+    max_retries: int | None = None,
+    output_limit: int | None = None,
+    timeout: int | None = None,
     clear_execution_mode: bool = False,
     clear_model: bool = False,
+    clear_max_retries: bool = False,
+    clear_output_limit: bool = False,
+    clear_timeout: bool = False,
     ctx: Context | None = None,
 ) -> str:
     """Set session-scoped preferences that apply to subsequent prompt/batch_prompt calls.
@@ -294,9 +315,18 @@ async def set_preferences(
             None retains the current session value (use clear_execution_mode=True to reset).
         model: Default model name for this session (e.g. 'gemini-2.5-flash').
             None retains the current session value (use clear_model=True to reset).
+        max_retries: Default max retry attempts for transient errors.
+            None retains the current session value (use clear_max_retries=True to reset).
+        output_limit: Default max output bytes per response.
+            None retains the current session value (use clear_output_limit=True to reset).
+        timeout: Default subprocess timeout in seconds.
+            None retains the current session value (use clear_timeout=True to reset).
         clear_execution_mode: If True, resets execution_mode to None regardless of the
             execution_mode argument.
         clear_model: If True, resets model to None regardless of the model argument.
+        clear_max_retries: If True, resets max_retries to None regardless of the argument.
+        clear_output_limit: If True, resets output_limit to None regardless of the argument.
+        clear_timeout: If True, resets timeout to None regardless of the argument.
         ctx: MCP context (auto-injected by FastMCP).
 
     Returns:
@@ -322,7 +352,37 @@ async def set_preferences(
     else:
         new_model = existing.model
 
-    merged = SessionPreferences(execution_mode=new_execution_mode, model=new_model)
+    new_max_retries: int | None
+    if clear_max_retries:
+        new_max_retries = None
+    elif max_retries is not None:
+        new_max_retries = max_retries
+    else:
+        new_max_retries = existing.max_retries
+
+    new_output_limit: int | None
+    if clear_output_limit:
+        new_output_limit = None
+    elif output_limit is not None:
+        new_output_limit = output_limit
+    else:
+        new_output_limit = existing.output_limit
+
+    new_timeout: int | None
+    if clear_timeout:
+        new_timeout = None
+    elif timeout is not None:
+        new_timeout = timeout
+    else:
+        new_timeout = existing.timeout
+
+    merged = SessionPreferences(
+        execution_mode=new_execution_mode,
+        model=new_model,
+        max_retries=new_max_retries,
+        output_limit=new_output_limit,
+        timeout=new_timeout,
+    )
     await ctx.set_state(_PREFERENCES_KEY, merged.model_dump())
     return f"Preferences set: {json.dumps(merged.model_dump())}"
 
@@ -331,7 +391,8 @@ async def get_preferences(ctx: Context | None = None) -> dict[str, Any]:
     """Return the current session preferences.
 
     Returns:
-        Dict with 'execution_mode' and 'model' keys (None when unset).
+        Dict with 'execution_mode', 'model', 'max_retries', 'output_limit', and 'timeout'
+        keys (None when unset).
     """
     if ctx is None:
         raise ToolError("get_preferences requires an active session context")

--- a/src/nexus_mcp/types.py
+++ b/src/nexus_mcp/types.py
@@ -12,6 +12,9 @@ class SessionPreferences(BaseModel):
 
     execution_mode: ExecutionMode | None = None
     model: str | None = Field(default=None, min_length=1)
+    max_retries: int | None = Field(default=None, ge=1)
+    output_limit: int | None = Field(default=None, ge=1)
+    timeout: int | None = Field(default=None, ge=1)
 
 
 DEFAULT_MAX_CONCURRENCY = 3
@@ -50,6 +53,16 @@ class PromptRequest(BaseModel):
         default=None,
         ge=1,
         description="Max retry attempts for transient errors (None uses NEXUS_RETRY_MAX_ATTEMPTS)",
+    )
+    output_limit: int | None = Field(
+        default=None,
+        ge=1,
+        description="Max output bytes (None uses NEXUS_OUTPUT_LIMIT_BYTES)",
+    )
+    timeout: int | None = Field(
+        default=None,
+        ge=1,
+        description="Subprocess timeout seconds (None uses NEXUS_TIMEOUT_SECONDS)",
     )
 
 
@@ -98,6 +111,8 @@ class AgentTask(BaseModel):
     execution_mode: ExecutionMode | None = None  # None = use session preference or "default"
     model: str | None = None
     max_retries: int | None = Field(default=None, ge=1)
+    output_limit: int | None = Field(default=None, ge=1)
+    timeout: int | None = Field(default=None, ge=1)
 
     def to_request(self) -> "PromptRequest":
         """Convert this task to a PromptRequest for runner execution."""
@@ -108,6 +123,8 @@ class AgentTask(BaseModel):
             execution_mode=self.execution_mode or "default",  # safety net: None → "default"
             model=self.model,
             max_retries=self.max_retries,
+            output_limit=self.output_limit,
+            timeout=self.timeout,
         )
 
 

--- a/tests/e2e/test_preferences_protocol.py
+++ b/tests/e2e/test_preferences_protocol.py
@@ -30,7 +30,13 @@ class TestPreferencesRoundTrip:
         """get_preferences before any set_preferences returns None values."""
         result = await mcp_client.call_tool("get_preferences", {})
         assert result.is_error is False
-        assert result.data == {"execution_mode": None, "model": None}
+        assert result.data == {
+            "execution_mode": None,
+            "model": None,
+            "max_retries": None,
+            "output_limit": None,
+            "timeout": None,
+        }
 
     async def test_set_model_preference(self, mcp_client):
         """set_preferences(model=...) is returned by get_preferences."""
@@ -51,7 +57,39 @@ class TestPreferencesRoundTrip:
         await mcp_client.call_tool("set_preferences", {"execution_mode": "yolo"})
         await mcp_client.call_tool("clear_preferences", {})
         result = await mcp_client.call_tool("get_preferences", {})
-        assert result.data == {"execution_mode": None, "model": None}
+        assert result.data == {
+            "execution_mode": None,
+            "model": None,
+            "max_retries": None,
+            "output_limit": None,
+            "timeout": None,
+        }
+
+    async def test_set_max_retries_preference(self, mcp_client):
+        """set_preferences(max_retries=5) is returned by get_preferences."""
+        await mcp_client.call_tool("set_preferences", {"max_retries": 5})
+        result = await mcp_client.call_tool("get_preferences", {})
+        assert result.data["max_retries"] == 5
+
+    async def test_set_output_limit_preference(self, mcp_client):
+        """set_preferences(output_limit=4096) is returned by get_preferences."""
+        await mcp_client.call_tool("set_preferences", {"output_limit": 4096})
+        result = await mcp_client.call_tool("get_preferences", {})
+        assert result.data["output_limit"] == 4096
+
+    async def test_set_timeout_preference(self, mcp_client):
+        """set_preferences(timeout=30) is returned by get_preferences."""
+        await mcp_client.call_tool("set_preferences", {"timeout": 30})
+        result = await mcp_client.call_tool("get_preferences", {})
+        assert result.data["timeout"] == 30
+
+    async def test_clear_individual_new_fields(self, mcp_client):
+        """clear_max_retries=True clears max_retries while preserving other fields."""
+        await mcp_client.call_tool("set_preferences", {"max_retries": 5, "timeout": 30})
+        await mcp_client.call_tool("set_preferences", {"clear_max_retries": True})
+        result = await mcp_client.call_tool("get_preferences", {})
+        assert result.data["max_retries"] is None
+        assert result.data["timeout"] == 30  # preserved
 
     async def test_set_preferences_returns_confirmation(self, mcp_client):
         """set_preferences returns a non-empty confirmation string."""

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -317,5 +317,11 @@ def make_session_preferences(**overrides: Any) -> SessionPreferences:
         prefs = make_session_preferences(execution_mode="yolo")    # override one field
         prefs = make_session_preferences(execution_mode="yolo", model="gemini-2.5-flash")
     """
-    defaults: dict[str, Any] = {"execution_mode": None, "model": None}
+    defaults: dict[str, Any] = {
+        "execution_mode": None,
+        "model": None,
+        "max_retries": None,
+        "output_limit": None,
+        "timeout": None,
+    }
     return SessionPreferences(**(defaults | overrides))

--- a/tests/unit/test_preferences.py
+++ b/tests/unit/test_preferences.py
@@ -109,6 +109,42 @@ class TestApplyPreferences:
         result = _apply_preferences(task, prefs)
         assert result == task
 
+    def test_fills_none_max_retries_from_prefs(self):
+        task = AgentTask(cli="gemini", prompt="hi")
+        prefs = make_session_preferences(max_retries=5)
+        result = _apply_preferences(task, prefs)
+        assert result.max_retries == 5
+
+    def test_does_not_override_explicit_max_retries(self):
+        task = AgentTask(cli="gemini", prompt="hi", max_retries=2)
+        prefs = make_session_preferences(max_retries=5)
+        result = _apply_preferences(task, prefs)
+        assert result.max_retries == 2
+
+    def test_fills_none_output_limit_from_prefs(self):
+        task = AgentTask(cli="gemini", prompt="hi")
+        prefs = make_session_preferences(output_limit=4096)
+        result = _apply_preferences(task, prefs)
+        assert result.output_limit == 4096
+
+    def test_does_not_override_explicit_output_limit(self):
+        task = AgentTask(cli="gemini", prompt="hi", output_limit=1024)
+        prefs = make_session_preferences(output_limit=4096)
+        result = _apply_preferences(task, prefs)
+        assert result.output_limit == 1024
+
+    def test_fills_none_timeout_from_prefs(self):
+        task = AgentTask(cli="gemini", prompt="hi")
+        prefs = make_session_preferences(timeout=30)
+        result = _apply_preferences(task, prefs)
+        assert result.timeout == 30
+
+    def test_does_not_override_explicit_timeout(self):
+        task = AgentTask(cli="gemini", prompt="hi", timeout=10)
+        prefs = make_session_preferences(timeout=30)
+        result = _apply_preferences(task, prefs)
+        assert result.timeout == 10
+
 
 # ---------------------------------------------------------------------------
 # TestSetPreferences
@@ -124,7 +160,14 @@ class TestSetPreferences:
         ctx.get_state.return_value = None  # no existing prefs
         result = await set_preferences(execution_mode="yolo", ctx=ctx)
         ctx.set_state.assert_awaited_once_with(
-            _PREFS_KEY, {"execution_mode": "yolo", "model": None}
+            _PREFS_KEY,
+            {
+                "execution_mode": "yolo",
+                "model": None,
+                "max_retries": None,
+                "output_limit": None,
+                "timeout": None,
+            },
         )
         assert "yolo" in result
 
@@ -132,14 +175,28 @@ class TestSetPreferences:
         ctx.get_state.return_value = None
         await set_preferences(model="gemini-2.5-flash", ctx=ctx)
         ctx.set_state.assert_awaited_once_with(
-            _PREFS_KEY, {"execution_mode": None, "model": "gemini-2.5-flash"}
+            _PREFS_KEY,
+            {
+                "execution_mode": None,
+                "model": "gemini-2.5-flash",
+                "max_retries": None,
+                "output_limit": None,
+                "timeout": None,
+            },
         )
 
     async def test_sets_both(self, ctx):
         ctx.get_state.return_value = None
         await set_preferences(execution_mode="yolo", model="gemini-2.5-flash", ctx=ctx)
         ctx.set_state.assert_awaited_once_with(
-            _PREFS_KEY, {"execution_mode": "yolo", "model": "gemini-2.5-flash"}
+            _PREFS_KEY,
+            {
+                "execution_mode": "yolo",
+                "model": "gemini-2.5-flash",
+                "max_retries": None,
+                "output_limit": None,
+                "timeout": None,
+            },
         )
 
     async def test_merges_with_existing_prefs(self, ctx):
@@ -147,7 +204,14 @@ class TestSetPreferences:
         ctx.get_state.return_value = {"execution_mode": "yolo", "model": None}
         await set_preferences(model="gemini-2.5-flash", ctx=ctx)
         ctx.set_state.assert_awaited_once_with(
-            _PREFS_KEY, {"execution_mode": "yolo", "model": "gemini-2.5-flash"}
+            _PREFS_KEY,
+            {
+                "execution_mode": "yolo",
+                "model": "gemini-2.5-flash",
+                "max_retries": None,
+                "output_limit": None,
+                "timeout": None,
+            },
         )
 
     async def test_all_none_params_preserves_existing(self, ctx):
@@ -155,7 +219,14 @@ class TestSetPreferences:
         ctx.get_state.return_value = {"execution_mode": "yolo", "model": "gemini-2.5-flash"}
         await set_preferences(ctx=ctx)
         ctx.set_state.assert_awaited_once_with(
-            _PREFS_KEY, {"execution_mode": "yolo", "model": "gemini-2.5-flash"}
+            _PREFS_KEY,
+            {
+                "execution_mode": "yolo",
+                "model": "gemini-2.5-flash",
+                "max_retries": None,
+                "output_limit": None,
+                "timeout": None,
+            },
         )
 
     async def test_returns_json_formatted_confirmation(self, ctx):
@@ -175,7 +246,14 @@ class TestSetPreferences:
         ctx.get_state.return_value = {"execution_mode": "yolo", "model": "gemini-2.5-flash"}
         await set_preferences(clear_execution_mode=True, ctx=ctx)
         ctx.set_state.assert_awaited_once_with(
-            _PREFS_KEY, {"execution_mode": None, "model": "gemini-2.5-flash"}
+            _PREFS_KEY,
+            {
+                "execution_mode": None,
+                "model": "gemini-2.5-flash",
+                "max_retries": None,
+                "output_limit": None,
+                "timeout": None,
+            },
         )
 
     async def test_clear_model_resets_to_none(self, ctx):
@@ -183,14 +261,138 @@ class TestSetPreferences:
         ctx.get_state.return_value = {"execution_mode": "yolo", "model": "gemini-2.5-flash"}
         await set_preferences(clear_model=True, ctx=ctx)
         ctx.set_state.assert_awaited_once_with(
-            _PREFS_KEY, {"execution_mode": "yolo", "model": None}
+            _PREFS_KEY,
+            {
+                "execution_mode": "yolo",
+                "model": None,
+                "max_retries": None,
+                "output_limit": None,
+                "timeout": None,
+            },
         )
 
     async def test_clear_flag_takes_precedence_over_value(self, ctx):
         """clear_execution_mode=True ignores any passed execution_mode value."""
         ctx.get_state.return_value = None
         await set_preferences(execution_mode="yolo", clear_execution_mode=True, ctx=ctx)
-        ctx.set_state.assert_awaited_once_with(_PREFS_KEY, {"execution_mode": None, "model": None})
+        ctx.set_state.assert_awaited_once_with(
+            _PREFS_KEY,
+            {
+                "execution_mode": None,
+                "model": None,
+                "max_retries": None,
+                "output_limit": None,
+                "timeout": None,
+            },
+        )
+
+    async def test_sets_max_retries(self, ctx):
+        """set_preferences(max_retries=5) stores max_retries."""
+        ctx.get_state.return_value = None
+        await set_preferences(max_retries=5, ctx=ctx)
+        ctx.set_state.assert_awaited_once_with(
+            _PREFS_KEY,
+            {
+                "execution_mode": None,
+                "model": None,
+                "max_retries": 5,
+                "output_limit": None,
+                "timeout": None,
+            },
+        )
+
+    async def test_sets_output_limit(self, ctx):
+        """set_preferences(output_limit=4096) stores output_limit."""
+        ctx.get_state.return_value = None
+        await set_preferences(output_limit=4096, ctx=ctx)
+        ctx.set_state.assert_awaited_once_with(
+            _PREFS_KEY,
+            {
+                "execution_mode": None,
+                "model": None,
+                "max_retries": None,
+                "output_limit": 4096,
+                "timeout": None,
+            },
+        )
+
+    async def test_sets_timeout(self, ctx):
+        """set_preferences(timeout=30) stores timeout."""
+        ctx.get_state.return_value = None
+        await set_preferences(timeout=30, ctx=ctx)
+        ctx.set_state.assert_awaited_once_with(
+            _PREFS_KEY,
+            {
+                "execution_mode": None,
+                "model": None,
+                "max_retries": None,
+                "output_limit": None,
+                "timeout": 30,
+            },
+        )
+
+    async def test_clear_max_retries(self, ctx):
+        """clear_max_retries=True resets max_retries to None."""
+        ctx.get_state.return_value = {
+            "execution_mode": None,
+            "model": None,
+            "max_retries": 5,
+            "output_limit": None,
+            "timeout": None,
+        }
+        await set_preferences(clear_max_retries=True, ctx=ctx)
+        ctx.set_state.assert_awaited_once_with(
+            _PREFS_KEY,
+            {
+                "execution_mode": None,
+                "model": None,
+                "max_retries": None,
+                "output_limit": None,
+                "timeout": None,
+            },
+        )
+
+    async def test_clear_output_limit(self, ctx):
+        """clear_output_limit=True resets output_limit to None."""
+        ctx.get_state.return_value = {
+            "execution_mode": None,
+            "model": None,
+            "max_retries": None,
+            "output_limit": 4096,
+            "timeout": None,
+        }
+        await set_preferences(clear_output_limit=True, ctx=ctx)
+        ctx.set_state.assert_awaited_once_with(
+            _PREFS_KEY,
+            {
+                "execution_mode": None,
+                "model": None,
+                "max_retries": None,
+                "output_limit": None,
+                "timeout": None,
+            },
+        )
+
+    async def test_clear_timeout(self, ctx):
+        """clear_timeout=True resets timeout to None."""
+        ctx.get_state.return_value = {
+            "execution_mode": None,
+            "model": None,
+            "max_retries": None,
+            "output_limit": None,
+            "timeout": 30,
+        }
+        await set_preferences(clear_timeout=True, ctx=ctx)
+        ctx.set_state.assert_awaited_once_with(
+            _PREFS_KEY,
+            {
+                "execution_mode": None,
+                "model": None,
+                "max_retries": None,
+                "output_limit": None,
+                "timeout": None,
+            },
+        )
 
     async def test_returns_confirmation_string(self, ctx):
         ctx.get_state.return_value = None
@@ -212,12 +414,24 @@ class TestGetPreferences:
     async def test_returns_prefs_dict(self, ctx):
         ctx.get_state.return_value = {"execution_mode": "yolo", "model": "gemini-2.5-flash"}
         result = await get_preferences(ctx=ctx)
-        assert result == {"execution_mode": "yolo", "model": "gemini-2.5-flash"}
+        assert result == {
+            "execution_mode": "yolo",
+            "model": "gemini-2.5-flash",
+            "max_retries": None,
+            "output_limit": None,
+            "timeout": None,
+        }
 
     async def test_returns_empty_defaults_when_no_prefs(self, ctx):
         ctx.get_state.return_value = None
         result = await get_preferences(ctx=ctx)
-        assert result == {"execution_mode": None, "model": None}
+        assert result == {
+            "execution_mode": None,
+            "model": None,
+            "max_retries": None,
+            "output_limit": None,
+            "timeout": None,
+        }
 
     async def test_returns_dict_not_pydantic(self, ctx):
         ctx.get_state.return_value = None
@@ -315,6 +529,74 @@ class TestPromptPreferenceFallback:
         result = await prompt(cli="gemini", prompt="test", ctx=None)
         assert result == "ok"
 
+    @patch("nexus_mcp.server.RunnerFactory")
+    async def test_session_max_retries_used_when_no_explicit(self, mock_factory, ctx):
+        """Session max_retries is used when prompt() called without explicit max_retries."""
+        mock_runner = _setup_mock_runner(mock_factory, output="ok")
+        ctx.get_state.return_value = {
+            "execution_mode": None,
+            "model": None,
+            "max_retries": 5,
+            "output_limit": None,
+            "timeout": None,
+        }
+
+        await prompt(cli="gemini", prompt="test", ctx=ctx)
+
+        call_args = mock_runner.run.call_args.args[0]
+        assert call_args.max_retries == 5
+
+    @patch("nexus_mcp.server.RunnerFactory")
+    async def test_explicit_max_retries_overrides_session(self, mock_factory, ctx):
+        """Explicit max_retries overrides session max_retries."""
+        mock_runner = _setup_mock_runner(mock_factory, output="ok")
+        ctx.get_state.return_value = {
+            "execution_mode": None,
+            "model": None,
+            "max_retries": 5,
+            "output_limit": None,
+            "timeout": None,
+        }
+
+        await prompt(cli="gemini", prompt="test", max_retries=2, ctx=ctx)
+
+        call_args = mock_runner.run.call_args.args[0]
+        assert call_args.max_retries == 2
+
+    @patch("nexus_mcp.server.RunnerFactory")
+    async def test_session_output_limit_used_when_no_explicit(self, mock_factory, ctx):
+        """Session output_limit is used when prompt() called without explicit output_limit."""
+        mock_runner = _setup_mock_runner(mock_factory, output="ok")
+        ctx.get_state.return_value = {
+            "execution_mode": None,
+            "model": None,
+            "max_retries": None,
+            "output_limit": 4096,
+            "timeout": None,
+        }
+
+        await prompt(cli="gemini", prompt="test", ctx=ctx)
+
+        call_args = mock_runner.run.call_args.args[0]
+        assert call_args.output_limit == 4096
+
+    @patch("nexus_mcp.server.RunnerFactory")
+    async def test_session_timeout_used_when_no_explicit(self, mock_factory, ctx):
+        """Session timeout is used when prompt() called without explicit timeout."""
+        mock_runner = _setup_mock_runner(mock_factory, output="ok")
+        ctx.get_state.return_value = {
+            "execution_mode": None,
+            "model": None,
+            "max_retries": None,
+            "output_limit": None,
+            "timeout": 30,
+        }
+
+        await prompt(cli="gemini", prompt="test", ctx=ctx)
+
+        call_args = mock_runner.run.call_args.args[0]
+        assert call_args.timeout == 30
+
 
 # ---------------------------------------------------------------------------
 # TestBatchPromptPreferenceFallback
@@ -368,6 +650,60 @@ class TestBatchPromptPreferenceFallback:
 
         call_args = mock_runner.run.call_args.args[0]
         assert call_args.execution_mode == "default"
+
+    @patch("nexus_mcp.server.RunnerFactory")
+    async def test_session_max_retries_applied_to_tasks(self, mock_factory, ctx):
+        """Session max_retries is applied to tasks with max_retries=None."""
+        mock_runner = _setup_mock_runner(mock_factory, output="ok")
+        ctx.get_state.return_value = {
+            "execution_mode": None,
+            "model": None,
+            "max_retries": 5,
+            "output_limit": None,
+            "timeout": None,
+        }
+
+        tasks = [AgentTask(cli="gemini", prompt="test")]
+        await batch_prompt(tasks=tasks, ctx=ctx)
+
+        call_args = mock_runner.run.call_args.args[0]
+        assert call_args.max_retries == 5
+
+    @patch("nexus_mcp.server.RunnerFactory")
+    async def test_session_output_limit_applied_to_tasks(self, mock_factory, ctx):
+        """Session output_limit is applied to tasks with output_limit=None."""
+        mock_runner = _setup_mock_runner(mock_factory, output="ok")
+        ctx.get_state.return_value = {
+            "execution_mode": None,
+            "model": None,
+            "max_retries": None,
+            "output_limit": 4096,
+            "timeout": None,
+        }
+
+        tasks = [AgentTask(cli="gemini", prompt="test")]
+        await batch_prompt(tasks=tasks, ctx=ctx)
+
+        call_args = mock_runner.run.call_args.args[0]
+        assert call_args.output_limit == 4096
+
+    @patch("nexus_mcp.server.RunnerFactory")
+    async def test_session_timeout_applied_to_tasks(self, mock_factory, ctx):
+        """Session timeout is applied to tasks with timeout=None."""
+        mock_runner = _setup_mock_runner(mock_factory, output="ok")
+        ctx.get_state.return_value = {
+            "execution_mode": None,
+            "model": None,
+            "max_retries": None,
+            "output_limit": None,
+            "timeout": 30,
+        }
+
+        tasks = [AgentTask(cli="gemini", prompt="test")]
+        await batch_prompt(tasks=tasks, ctx=ctx)
+
+        call_args = mock_runner.run.call_args.args[0]
+        assert call_args.timeout == 30
 
     @patch("nexus_mcp.server.RunnerFactory")
     async def test_mixed_tasks_selective_apply(self, mock_factory, ctx):

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -331,6 +331,8 @@ def test_agent_task_to_request_maps_all_fields():
         execution_mode="yolo",
         model="gemini-2.5-flash",
         max_retries=2,
+        output_limit=1024,
+        timeout=30,
     )
     req = task.to_request()
     assert isinstance(req, PromptRequest)
@@ -339,6 +341,8 @@ def test_agent_task_to_request_maps_all_fields():
     assert req.execution_mode == "yolo"
     assert req.model == "gemini-2.5-flash"
     assert req.max_retries == 2
+    assert req.output_limit == 1024
+    assert req.timeout == 30
 
 
 def test_agent_task_to_request_defaults():
@@ -348,7 +352,57 @@ def test_agent_task_to_request_defaults():
     assert req.execution_mode == "default"
     assert req.model is None
     assert req.max_retries is None
+    assert req.output_limit is None
+    assert req.timeout is None
     assert req.context == {}
+
+
+def test_prompt_request_output_limit_defaults_to_none():
+    """PromptRequest.output_limit defaults to None (falls back to env default)."""
+    req = PromptRequest(cli="gemini", prompt="Hello")
+    assert req.output_limit is None
+
+
+def test_prompt_request_output_limit_accepts_positive():
+    """PromptRequest.output_limit accepts a positive integer."""
+    req = PromptRequest(cli="gemini", prompt="Hello", output_limit=4096)
+    assert req.output_limit == 4096
+
+
+def test_prompt_request_output_limit_rejects_zero():
+    """PromptRequest.output_limit=0 is rejected by ge=1."""
+    with pytest.raises(ValidationError):
+        PromptRequest(cli="gemini", prompt="Hello", output_limit=0)
+
+
+def test_prompt_request_timeout_defaults_to_none():
+    """PromptRequest.timeout defaults to None (falls back to env default)."""
+    req = PromptRequest(cli="gemini", prompt="Hello")
+    assert req.timeout is None
+
+
+def test_prompt_request_timeout_accepts_positive():
+    """PromptRequest.timeout accepts a positive integer."""
+    req = PromptRequest(cli="gemini", prompt="Hello", timeout=60)
+    assert req.timeout == 60
+
+
+def test_prompt_request_timeout_rejects_zero():
+    """PromptRequest.timeout=0 is rejected by ge=1."""
+    with pytest.raises(ValidationError):
+        PromptRequest(cli="gemini", prompt="Hello", timeout=0)
+
+
+def test_agent_task_output_limit_defaults_to_none():
+    """AgentTask.output_limit defaults to None."""
+    task = AgentTask(cli="gemini", prompt="Hello")
+    assert task.output_limit is None
+
+
+def test_agent_task_timeout_defaults_to_none():
+    """AgentTask.timeout defaults to None."""
+    task = AgentTask(cli="gemini", prompt="Hello")
+    assert task.timeout is None
 
 
 # ---------------------------------------------------------------------------
@@ -375,10 +429,13 @@ def test_agent_task_result_formatted_error_without_type():
 
 class TestSessionPreferences:
     def test_default_values_are_none(self):
-        """SessionPreferences defaults: both execution_mode and model are None."""
+        """SessionPreferences defaults: all fields are None."""
         prefs = SessionPreferences()
         assert prefs.execution_mode is None
         assert prefs.model is None
+        assert prefs.max_retries is None
+        assert prefs.output_limit is None
+        assert prefs.timeout is None
 
     def test_accepts_valid_execution_modes(self):
         """All ExecutionMode values are accepted."""
@@ -408,11 +465,60 @@ class TestSessionPreferences:
 
     def test_model_dump_round_trip(self):
         """model_dump() → SessionPreferences(**d) round-trip preserves values."""
-        prefs = SessionPreferences(execution_mode="yolo", model="gemini-2.5-flash")
+        prefs = SessionPreferences(
+            execution_mode="yolo",
+            model="gemini-2.5-flash",
+            max_retries=3,
+            output_limit=1024,
+            timeout=30,
+        )
         d = prefs.model_dump()
         reconstructed = SessionPreferences(**d)
         assert reconstructed.execution_mode == "yolo"
         assert reconstructed.model == "gemini-2.5-flash"
+        assert reconstructed.max_retries == 3
+        assert reconstructed.output_limit == 1024
+        assert reconstructed.timeout == 30
+
+    def test_max_retries_accepts_positive(self):
+        """max_retries accepts a positive integer."""
+        prefs = SessionPreferences(max_retries=5)
+        assert prefs.max_retries == 5
+
+    def test_max_retries_rejects_zero(self):
+        """max_retries=0 is rejected by ge=1."""
+        with pytest.raises(ValidationError):
+            SessionPreferences(max_retries=0)
+
+    def test_max_retries_rejects_negative(self):
+        """Negative max_retries is rejected by ge=1."""
+        with pytest.raises(ValidationError):
+            SessionPreferences(max_retries=-1)
+
+    def test_output_limit_accepts_positive(self):
+        """output_limit accepts a positive integer."""
+        prefs = SessionPreferences(output_limit=4096)
+        assert prefs.output_limit == 4096
+
+    def test_output_limit_rejects_zero(self):
+        """output_limit=0 is rejected by ge=1."""
+        with pytest.raises(ValidationError):
+            SessionPreferences(output_limit=0)
+
+    def test_timeout_accepts_positive(self):
+        """timeout accepts a positive integer."""
+        prefs = SessionPreferences(timeout=60)
+        assert prefs.timeout == 60
+
+    def test_timeout_rejects_zero(self):
+        """timeout=0 is rejected by ge=1."""
+        with pytest.raises(ValidationError):
+            SessionPreferences(timeout=0)
+
+    def test_timeout_rejects_negative(self):
+        """Negative timeout is rejected by ge=1."""
+        with pytest.raises(ValidationError):
+            SessionPreferences(timeout=-10)
 
     def test_frozen(self):
         """SessionPreferences is immutable (frozen=True)."""


### PR DESCRIPTION
Extend session preferences to include max_retries, output_limit, and timeout settings. These values are automatically applied to prompt and batch_prompt calls unless explicitly overridden. Updated the runner base class to respect these dynamic configuration values during subprocess execution and output truncation.