### PR TITLE
fix(ci): use binary download for mcp-publisher

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,7 +155,9 @@ jobs:
           mv server.tmp.json server.json
 
       - name: Install mcp-publisher
-        run: npm install -g @anthropic-ai/mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
+          sudo mv mcp-publisher /usr/local/bin/
 
       - name: Authenticate to MCP Registry
         run: mcp-publisher login github-oidc


### PR DESCRIPTION
## Summary

- Replace `npm install -g @anthropic-ai/mcp-publisher` with binary download from GitHub Releases
- `mcp-publisher` is a Go binary, not an npm package — the npm install was returning 404

Fixes the `publish-mcp-registry` job failure in [run #23403273772](https://github.com/j7an/nexus-mcp/actions/runs/23403273772/job/68077997612).

## Test plan

- [ ] Re-run the release workflow after merge to verify the install step succeeds