### PR TITLE
fix: shorten server.json description to meet registry limit

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.j7an/nexus-mcp",
-  "description": "MCP server that lets AI models invoke CLI agents (Gemini, Codex, Claude, OpenCode) as tools — with parallel execution, retries, and structured output parsing.",
+  "description": "Invoke CLI agents (Gemini, Codex, Claude, OpenCode) as MCP tools with parallel execution",
   "version": "0.8.1",
   "repository": {
     "url": "https://github.com/j7an/nexus-mcp",


### PR DESCRIPTION
## Summary

- Shorten `server.json` description from 161 to 88 characters (registry enforces <= 100)

Fixes the `publish-mcp-registry` job 422 validation error in [run #23403484426](https://github.com/j7an/nexus-mcp/actions/runs/23403484426/job/68078524708).

## Test plan

- [ ] Re-run release workflow after merge to verify registry publish succeeds