### PR TITLE
feat: add runner metadata header to tool responses

### DIFF
--- a/src/nexus_mcp/elicitation.py
+++ b/src/nexus_mcp/elicitation.py
@@ -5,6 +5,7 @@ execution mode, prompt) before a tool call proceeds. Falls back gracefully when
 the client does not support elicitation.
 """
 
+import dataclasses
 import logging
 from dataclasses import dataclass
 from typing import Any
@@ -36,6 +37,10 @@ type ElicitResult = (
 )
 
 
+SELECTED = "user-selected"
+DECLINED = "declined"
+
+
 @dataclass(frozen=True)
 class ResolvedParams:
     """Fully-resolved parameters after elicitation."""
@@ -44,6 +49,7 @@ class ResolvedParams:
     model: str | None
     execution_mode: ExecutionMode
     prompt_text: str
+    selections: dict[str, str] = dataclasses.field(default_factory=dict)
 
 
 class ElicitationGuard:
@@ -134,6 +140,7 @@ class ElicitationGuard:
         resolved_model = model
         resolved_mode = execution_mode
         resolved_prompt = prompt_text
+        selections: dict[str, str] = {}
 
         # Trigger #1: CLI disambiguation
         if resolved_cli is None:
@@ -145,6 +152,7 @@ class ElicitationGuard:
                 raise ToolError("cli is required — elicitation was declined or unavailable")
             assert isinstance(result, AcceptedElicitation)
             resolved_cli = str(result.data)
+            selections["cli"] = SELECTED
 
         # Trigger #2: Model selection
         if resolved_model is None and resolved_cli:
@@ -157,6 +165,9 @@ class ElicitationGuard:
                 if result is not None and result.action == "accept":
                     assert isinstance(result, AcceptedElicitation)
                     resolved_model = str(result.data)
+                    selections["model"] = SELECTED
+                else:
+                    selections["model"] = DECLINED
 
         # Trigger #3: YOLO confirmation
         if resolved_mode == "yolo" and self._prefs.confirm_yolo is not False:
@@ -168,8 +179,10 @@ class ElicitationGuard:
                 pass  # elicitation unavailable, proceed
             elif result.action == "accept":
                 await self._auto_suppress("confirm_yolo")
+                selections["mode"] = SELECTED
             else:
                 resolved_mode = "default"
+                selections["mode"] = DECLINED
                 logger.warning("YOLO mode declined, downgrading to default")
 
         # Trigger #4: Vague prompt check (no auto-suppress)
@@ -185,6 +198,9 @@ class ElicitationGuard:
             if result is not None and result.action == "accept":
                 assert isinstance(result, AcceptedElicitation)
                 resolved_prompt = str(result.data)
+                selections["prompt"] = SELECTED
+            else:
+                selections["prompt"] = DECLINED
 
         # resolved_cli is guaranteed non-None here: either it was provided,
         # or Trigger #1 set it (raising ToolError if it couldn't).
@@ -194,6 +210,7 @@ class ElicitationGuard:
             model=resolved_model,
             execution_mode=resolved_mode,
             prompt_text=resolved_prompt,
+            selections=selections,
         )
 
     async def check_batch(

--- a/src/nexus_mcp/server.py
+++ b/src/nexus_mcp/server.py
@@ -62,6 +62,10 @@ def build_server_instructions() -> str:
     without needing a separate tool call.
     """
     lines = ["# nexus-mcp — CLI Agent Router", ""]
+    lines.append("## Important: Do not pre-fill `cli` or `model`")
+    lines.append("Leave `cli` and `model` empty so the user can choose interactively.")
+    lines.append("Only set them when the user explicitly names a runner or model.")
+    lines.append("")
     lines.append("## Available Runners")
     lines.append("")
 
@@ -282,6 +286,11 @@ async def batch_prompt(
             if t.cli is None:
                 raise ToolError("cli is required on all tasks when no context available")
 
+    def _metadata_header(task: AgentTask) -> str:
+        """Build a short metadata line so the AI knows which runner handled the task."""
+        model_part = task.model or "default"
+        return f"[cli: {task.cli} | model: {model_part} | mode: {task.execution_mode}]"
+
     labelled = _assign_labels(tasks)
     semaphore = asyncio.Semaphore(max_concurrency)
     is_single_task = len(labelled) == 1
@@ -307,7 +316,9 @@ async def batch_prompt(
                 request = task.to_request()
                 runner = RunnerFactory.create(request.cli)
                 response = await runner.run(request, emitter=emitter, progress=progress)
-                return AgentTaskResult(label=task.label, output=response.output)  # type: ignore[arg-type]
+                header = _metadata_header(task)
+                output = f"{header}\n\n{response.output}"
+                return AgentTaskResult(label=task.label, output=output)  # type: ignore[arg-type]
             except Exception as e:
                 if emitter:
                     await emitter("error", f"Task '{task.label}' failed: {e}")
@@ -343,11 +354,11 @@ async def prompt(
     This prevents timeouts for long operations (YOLO mode: 2-5 minutes).
 
     Args:
-        cli: CLI runner name (e.g., "gemini")
+        cli: CLI runner name (e.g., "gemini"). None triggers interactive selection.
         prompt: Prompt text to send to the runner
         context: Optional context metadata
         execution_mode: 'default' (safe) or 'yolo'. None inherits session preference.
-        model: Optional model name. None inherits session preference or uses CLI default.
+        model: Model name. None triggers interactive selection or uses CLI default.
         max_retries: Max retry attempts for transient errors (None inherits session preference).
         output_limit: Max output bytes (None inherits session preference or uses env default).
         timeout: Subprocess timeout seconds (None inherits session preference or uses env default).
@@ -382,6 +393,7 @@ async def prompt(
         if ctx
         else None
     )
+    selections: dict[str, str] = {}
     if guard:
         resolved = await guard.check_prompt(
             cli=cli,
@@ -394,6 +406,7 @@ async def prompt(
         resolved_model = resolved.model
         resolved_mode = resolved.execution_mode
         prompt = resolved.prompt_text
+        selections = resolved.selections
     elif cli is None:
         raise ToolError("cli is required")
 
@@ -414,7 +427,15 @@ async def prompt(
     if task_result.error:
         raise ToolError(task_result.formatted_error)
     assert task_result.output is not None  # guaranteed: error is None, so output was set
-    return task_result.output
+
+    # Annotate per-field using elicitation selections.
+    output = task_result.output
+    field_map = {"cli": cli, "model": resolved_model or "default", "mode": resolved_mode}
+    for field, value in field_map.items():
+        status = selections.get(field)
+        if status:
+            output = output.replace(f"{field}: {value}", f"{field}: {value} ({status})", 1)
+    return output
 
 
 # Inject CLI names as enum into tool schemas before registration freezes them.

--- a/tests/e2e/test_elicitation_e2e.py
+++ b/tests/e2e/test_elicitation_e2e.py
@@ -14,7 +14,7 @@ import pytest
 from fastmcp.exceptions import ToolError
 
 from nexus_mcp.elicitation import ElicitationGuard
-from tests.fixtures import GEMINI_JSON_RESPONSE, create_mock_process
+from tests.fixtures import GEMINI_JSON_RESPONSE, create_mock_process, strip_runner_header
 
 
 @pytest.fixture(autouse=True)
@@ -45,7 +45,7 @@ class TestElicitationGracefulSkip:
         )
 
         assert result.is_error is False
-        assert result.data == "test output"
+        assert strip_runner_header(result.data) == "test output"
 
     async def test_prompt_without_cli_and_elicit_false_errors(self, mcp_client):
         """prompt without cli and elicit=False raises ToolError about cli being required."""

--- a/tests/e2e/test_mcp_protocol.py
+++ b/tests/e2e/test_mcp_protocol.py
@@ -22,6 +22,7 @@ from tests.fixtures import (
     create_mock_process,
     gemini_error_json,
     gemini_json,
+    strip_runner_header,
 )
 
 
@@ -122,7 +123,7 @@ class TestPromptProtocol:
         result = await mcp_client.call_tool("prompt", {"cli": "gemini", "prompt": "say hello"})
 
         assert result.is_error is False
-        assert result.data == "hello from e2e"
+        assert strip_runner_header(result.data) == "hello from e2e"
 
     async def test_task_true_lifecycle(self, mock_subprocess, mcp_client):
         """task=True returns a ToolTask; awaiting it resolves to the final output."""
@@ -134,7 +135,7 @@ class TestPromptProtocol:
         result = await task
 
         assert result.is_error is False
-        assert result.data == "task result"
+        assert strip_runner_header(result.data) == "task result"
 
     async def test_model_parameter_reaches_subprocess(self, mock_subprocess, mcp_client):
         """model parameter survives JSON-RPC round-trip and appears in subprocess args."""
@@ -168,7 +169,7 @@ class TestPromptProtocol:
         result = await mcp_client.call_tool("prompt", {"cli": "gemini", "prompt": "noisy test"})
 
         assert result.is_error is False
-        assert result.data == "test output"
+        assert strip_runner_header(result.data) == "test output"
 
     @pytest.mark.parametrize(
         ("error_code", "error_message", "error_status"),
@@ -200,7 +201,7 @@ class TestPromptProtocol:
         )
 
         assert result.is_error is False
-        assert result.data == "ok after retry"
+        assert strip_runner_header(result.data) == "ok after retry"
         assert mock_subprocess.call_count == 2
 
     async def test_opencode_success_returns_parsed_ndjson(self, mock_subprocess, mcp_client):
@@ -208,7 +209,7 @@ class TestPromptProtocol:
         mock_subprocess.return_value = create_mock_process(stdout=OPENCODE_NDJSON_RESPONSE)
         result = await mcp_client.call_tool("prompt", {"cli": "opencode", "prompt": "say hello"})
         assert result.is_error is False
-        assert result.data == "test output"
+        assert strip_runner_header(result.data) == "test output"
 
     async def test_context_parameter_survives_json_rpc(self, mock_subprocess, mcp_client):
         """context dict survives JSON-RPC round-trip; call succeeds (context is pass-through)."""
@@ -224,7 +225,7 @@ class TestPromptProtocol:
         )
 
         assert result.is_error is False
-        assert result.data == "ok"
+        assert strip_runner_header(result.data) == "ok"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/e2e/test_middleware_integration.py
+++ b/tests/e2e/test_middleware_integration.py
@@ -40,8 +40,11 @@ class TestMiddlewarePipeline:
         assert "completed in" in caplog.text
         assert "ms" in caplog.text
 
-        # Prompt text not leaked
-        assert "say hello" not in caplog.text
+        # Prompt text not leaked in middleware logs
+        middleware_text = " ".join(
+            r.message for r in caplog.records if r.name == "nexus_mcp.middleware"
+        )
+        assert "say hello" not in middleware_text
 
     async def test_error_normalization_propagates_tool_error(self, mcp_client, caplog):
         """ToolError from batch_prompt propagates through the middleware stack.

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -152,6 +152,26 @@ OPENCODE_NOISY_STDOUT = (
 PING_PROMPT = "Reply with exactly the word 'pong'"
 
 
+def strip_runner_header(output: str) -> str:
+    """Strip the [cli: ...] metadata header prepended by the server.
+
+    Server output format:
+        [cli: gemini | model: default | mode: default]
+
+        <actual runner output>
+
+    Also handles the elicitation-annotated variant:
+        [cli (user-selected cli, model): opencode | model: minimax | mode: default]
+
+    Returns only the runner output after the header and blank line separator.
+    """
+    if output.startswith("[cli"):
+        idx = output.find("]\n\n")
+        if idx != -1:
+            return output[idx + 3 :]
+    return output
+
+
 # ---------------------------------------------------------------------------
 # CLI detection mock helpers
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_preferences.py
+++ b/tests/unit/test_preferences.py
@@ -15,7 +15,7 @@ from nexus_mcp.preferences import (
 )
 from nexus_mcp.server import batch_prompt, prompt
 from nexus_mcp.types import AgentTask, SessionPreferences
-from tests.fixtures import make_agent_response, make_session_preferences
+from tests.fixtures import make_agent_response, make_session_preferences, strip_runner_header
 
 _PREFS_KEY = "nexus:preferences"
 
@@ -772,7 +772,7 @@ class TestPromptPreferenceFallback:
         """prompt() with ctx=None falls back to defaults without raising."""
         _setup_mock_runner(mock_factory, output="ok")
         result = await prompt(cli="gemini", prompt="test", ctx=None)
-        assert result == "ok"
+        assert strip_runner_header(result) == "ok"
 
     @patch("nexus_mcp.server.RunnerFactory")
     async def test_session_max_retries_used_when_no_explicit(self, mock_factory, ctx):

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -32,6 +32,7 @@ from tests.fixtures import (
     create_mock_process,
     make_agent_response,
     make_agent_task,
+    strip_runner_header,
 )
 
 
@@ -68,7 +69,7 @@ class TestPrompt:
             prompt="Test prompt",
         )
 
-        assert result == "Agent response"
+        assert strip_runner_header(result) == "Agent response"
         mock_factory.create.assert_called_once_with("gemini")
         call_args = mock_runner.run.call_args.args[0]
         assert call_args.prompt == "Test prompt"
@@ -309,7 +310,9 @@ class TestBatchPrompt:
 
         assert result.succeeded == 1
         assert result.failed == 1
-        ok_result = next(r for r in result.results if r.output == "good output")
+        ok_result = next(
+            r for r in result.results if strip_runner_header(r.output or "") == "good output"
+        )
         assert ok_result is not None
 
     @patch("nexus_mcp.server.RunnerFactory")
@@ -358,7 +361,7 @@ class TestBatchPrompt:
         tasks = [make_agent_task(prompt=f"p{i}") for i in range(3)]
         result = await batch_prompt(tasks=tasks)
 
-        outputs = [r.output for r in result.results]
+        outputs = [strip_runner_header(r.output or "") for r in result.results]
         assert outputs == ["result-p0", "result-p1", "result-p2"]
 
     @patch("nexus_mcp.server.RunnerFactory")

--- a/tests/unit/test_server_claude_pipeline.py
+++ b/tests/unit/test_server_claude_pipeline.py
@@ -19,6 +19,7 @@ from tests.fixtures import (
     CLAUDE_NOISY_STDOUT,
     create_mock_process,
     make_agent_task,
+    strip_runner_header,
 )
 from tests.fixtures import (
     claude_error_json as _claude_error_json,
@@ -63,7 +64,7 @@ class TestPromptClaudePipeline:
 
         result = await prompt(cli="claude", prompt="Say hello")
 
-        assert result == "Hello from Claude"
+        assert strip_runner_header(result) == "Hello from Claude"
         assert mock_subprocess.call_count == 1
         args = list(mock_subprocess.call_args.args)
         assert "-p" in args
@@ -114,7 +115,7 @@ class TestPromptClaudePipeline:
 
         result = await prompt(cli="claude", prompt="test", max_retries=2)
 
-        assert result == "ok after retry"
+        assert strip_runner_header(result) == "ok after retry"
         assert mock_subprocess.call_count == 2
 
     async def test_recovery_from_nonzero_exit(self, mock_subprocess):
@@ -125,7 +126,7 @@ class TestPromptClaudePipeline:
 
         result = await prompt(cli="claude", prompt="test")
 
-        assert result == "recovered output"
+        assert strip_runner_header(result) == "recovered output"
 
     async def test_noisy_stdout_parsed(self, mock_subprocess):
         """Log lines before JSON → still parsed correctly via fallback."""
@@ -133,7 +134,7 @@ class TestPromptClaudePipeline:
 
         result = await prompt(cli="claude", prompt="test")
 
-        assert result == "test output"
+        assert strip_runner_header(result) == "test output"
 
     async def test_exhausted_retries_503(self, mock_subprocess, fast_retry_sleep):
         """HTTP 503 that always fails → exhausts all retries → ToolError with [RetryableError]."""

--- a/tests/unit/test_server_codex_pipeline.py
+++ b/tests/unit/test_server_codex_pipeline.py
@@ -12,7 +12,7 @@ import pytest
 from fastmcp.exceptions import ToolError
 
 from nexus_mcp.server import prompt
-from tests.fixtures import CODEX_NDJSON_RESPONSE, create_mock_process
+from tests.fixtures import CODEX_NDJSON_RESPONSE, create_mock_process, strip_runner_header
 
 
 def _codex_ndjson(text: str) -> str:
@@ -45,7 +45,7 @@ class TestPromptCodexPipeline:
 
         result = await prompt(cli="codex", prompt="ping")
 
-        assert result == "pong"
+        assert strip_runner_header(result) == "pong"
         assert mock_subprocess.call_count == 1
         args = list(mock_subprocess.call_args.args)
         assert "exec" in args
@@ -85,7 +85,7 @@ class TestPromptCodexPipeline:
 
         result = await prompt(cli="codex", prompt="test")
 
-        assert result == "pong"
+        assert strip_runner_header(result) == "pong"
 
     async def test_429_retries_then_succeeds(self, mock_subprocess, fast_retry_sleep):
         """HTTP 429 in stderr triggers retry; second attempt succeeds."""
@@ -97,7 +97,7 @@ class TestPromptCodexPipeline:
 
         result = await prompt(cli="codex", prompt="test", max_retries=2)
 
-        assert result == "pong"
+        assert strip_runner_header(result) == "pong"
         assert mock_subprocess.call_count == 2
 
     async def test_multiple_agent_messages_joined(self, mock_subprocess):
@@ -112,4 +112,4 @@ class TestPromptCodexPipeline:
 
         result = await prompt(cli="codex", prompt="test")
 
-        assert result == "part1\n\npart2"
+        assert strip_runner_header(result) == "part1\n\npart2"

--- a/tests/unit/test_server_gemini_pipeline.py
+++ b/tests/unit/test_server_gemini_pipeline.py
@@ -15,7 +15,12 @@ import pytest
 from fastmcp.exceptions import ToolError
 
 from nexus_mcp.server import batch_prompt, prompt
-from tests.fixtures import GEMINI_NOISY_STDOUT, create_mock_process, make_agent_task
+from tests.fixtures import (
+    GEMINI_NOISY_STDOUT,
+    create_mock_process,
+    make_agent_task,
+    strip_runner_header,
+)
 
 # ---------------------------------------------------------------------------
 # JSON response builders
@@ -55,7 +60,7 @@ class TestPromptGeminiPipeline:
 
         result = await prompt(cli="gemini", prompt="Say hello")
 
-        assert result == "Hello from Gemini"
+        assert strip_runner_header(result) == "Hello from Gemini"
         assert mock_subprocess.call_count == 1
         args = list(mock_subprocess.call_args.args)
         assert "-p" in args
@@ -110,7 +115,7 @@ class TestPromptGeminiPipeline:
 
         result = await prompt(cli="gemini", prompt="test", max_retries=2)
 
-        assert result == "ok after retry"
+        assert strip_runner_header(result) == "ok after retry"
         assert mock_subprocess.call_count == 2
 
     async def test_noisy_stdout_parses_correctly(self, mock_subprocess):
@@ -119,7 +124,7 @@ class TestPromptGeminiPipeline:
 
         result = await prompt(cli="gemini", prompt="test")
 
-        assert result == "test output"
+        assert strip_runner_header(result) == "test output"
 
     async def test_recovery_from_nonzero_exit_with_valid_json(self, mock_subprocess):
         """Non-zero exit with valid response JSON → recovery path → output returned."""
@@ -129,7 +134,7 @@ class TestPromptGeminiPipeline:
 
         result = await prompt(cli="gemini", prompt="test")
 
-        assert result == "recovered output"
+        assert strip_runner_header(result) == "recovered output"
 
     async def test_503_exhausts_retries_raises_tool_error(self, mock_subprocess, fast_retry_sleep):
         """HTTP 503 that always fails → exhausts all retries → ToolError with [RetryableError]."""


### PR DESCRIPTION
## Summary
- Tool responses now include a `[cli: X | model: Y | mode: Z]` metadata header so the calling AI model knows which runner handled the request
- Elicitation selections are annotated as `(user-selected)` or `(declined)` — prevents the AI from hallucinating "default runner was used" when the user chose interactively
- Server instructions nudge AI clients to leave `cli`/`model` empty for interactive selection via elicitation

## Problem
When parameters were resolved via MCP elicitation (inside the tool), the calling AI couldn't see what was selected — only the original null arguments. It would then narrate "used default runner (likely Claude)" even when the user explicitly chose OpenCode via the elicitation prompt.

## Changes
- `elicitation.py`: Add `selections` dict to `ResolvedParams` tracking `SELECTED`/`DECLINED` per field across all 4 elicitation triggers
- `server.py`: Prepend metadata header in `_run_single()`, annotate per-field selections in `prompt()`, add server instructions for AI clients
- `tests/fixtures.py`: Add `strip_runner_header()` helper
- Test files: Update 25 assertions to use `strip_runner_header()`

## Test plan
- [x] All 906 unit + e2e tests pass
- [x] Manual verification: CLI/model show `(user-selected)` when chosen via elicitation
- [x] Manual verification: declined YOLO shows `mode: default (declined)`
- [x] Manual verification: AI narrates correct runner after metadata header