### PR TITLE
feat: add runtime Python version check

### DIFF
--- a/src/nexus_mcp/__main__.py
+++ b/src/nexus_mcp/__main__.py
@@ -6,8 +6,35 @@ Usage:
     uvx nexus-mcp
 """
 
-import logging
 import sys
+
+
+def _check_python_version() -> None:
+    """Exit early with a clear message if Python version is too old.
+
+    Reads requires-python from installed package metadata so the minimum
+    version stays in sync with pyproject.toml automatically.
+    """
+    import re
+    from importlib.metadata import metadata
+
+    requires_python = metadata("nexus-mcp").get("Requires-Python", "")
+    match = re.search(r">=\s*(\d+)\.(\d+)", requires_python)
+    if not match:
+        return
+    min_major, min_minor = int(match.group(1)), int(match.group(2))
+    if sys.version_info >= (min_major, min_minor):
+        return
+    sys.exit(
+        f"nexus-mcp requires Python {min_major}.{min_minor}+, "
+        f"but you are running Python {sys.version_info[0]}.{sys.version_info[1]}.\n"
+        "Install with: uvx nexus-mcp  (uv auto-downloads the correct Python)"
+    )
+
+
+_check_python_version()
+
+import logging  # noqa: E402 — must run version check before importing project code
 
 
 def main() -> None:

--- a/tests/unit/test___main__.py
+++ b/tests/unit/test___main__.py
@@ -1,0 +1,35 @@
+# tests/unit/test___main__.py
+"""Tests for the Python version check in __main__.py."""
+
+from unittest.mock import patch
+
+import pytest
+
+from nexus_mcp.__main__ import _check_python_version
+
+
+class TestCheckPythonVersion:
+    """Tests for _check_python_version()."""
+
+    def test_exits_on_old_python(self):
+        """Simulates Python 3.11 to trigger the version warning."""
+        fake_version = (3, 11, 0, "final", 0)
+        with (
+            patch.object(__import__("sys"), "version_info", fake_version),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            _check_python_version()
+
+        message = str(exc_info.value)
+        assert "requires Python 3.13+" in message
+        assert "running Python 3.11" in message
+        assert "uvx nexus-mcp" in message
+
+    def test_passes_on_current_python(self):
+        """No exit when running on a supported Python version."""
+        _check_python_version()  # Should not raise
+
+    def test_passes_when_no_requires_python(self):
+        """Gracefully handles missing Requires-Python metadata."""
+        with patch("importlib.metadata.metadata", return_value={}):
+            _check_python_version()  # Should not raise


### PR DESCRIPTION
## Summary
- Adds a runtime check in `__main__.py` that exits with a clear message if Python < 3.13
- Reads minimum version from installed package metadata (`importlib.metadata`) so it stays in sync with `pyproject.toml` automatically — no hardcoded version to maintain
- Users see: `nexus-mcp requires Python 3.13+, but you are running Python 3.11. Install with: uvx nexus-mcp`

## Test plan
- [x] Unit test mocks `sys.version_info` to `(3, 11)` and asserts `SystemExit` with correct message
- [x] Unit test verifies no exit on current Python
- [x] Unit test verifies graceful handling when `Requires-Python` metadata is missing
- [x] All 948 existing tests pass