### PR TITLE
fix: rename prHourLimit to prHourlyLimit in renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
   "enabledManagers": ["github-actions"],
-  "prHourLimit": 5,
+  "prHourlyLimit": 5,
   "prConcurrentLimit": 3,
   "packageRules": [
     {


### PR DESCRIPTION
## Summary

- Rename deprecated `prHourLimit` to `prHourlyLimit` in Renovate config

## Motivation

Renovate v43+ renamed this option. The old name causes a config-validation error that prevents Renovate from running (see issue #104).

## Test plan

- [ ] Renovate runs successfully after merge (check [Mend dashboard](https://developer.mend.io/github/j7an/nexus-mcp))
- [ ] Issue #104 auto-closes