### PR TITLE
test: reduce integration tests from 31 to 11

### DIFF
--- a/tests/integration/test_claude_runner.py
+++ b/tests/integration/test_claude_runner.py
@@ -1,17 +1,9 @@
 # tests/integration/test_claude_runner.py
-"""Integration tests for ClaudeRunner end-to-end pipeline.
+"""Integration tests for ClaudeRunner with real CLI binary.
 
-Tests exercise the full Template Method pipeline:
-  build_command() → run_subprocess() → parse_output()
-using the real Claude Code CLI binary.
-
-Tests marked @slow make real API calls and require valid credentials.
-
-Run with:
-    uv run pytest -m integration -v
+Minimal set — only tests that require a real CLI binary.
+Command building, JSON parsing, and retry logic are covered by unit tests.
 """
-
-import shutil
 
 import pytest
 
@@ -21,116 +13,31 @@ from tests.fixtures import PING_PROMPT, make_prompt_request
 
 
 @pytest.mark.integration
-class TestClaudeRunnerConstruction:
-    """Validate ClaudeRunner.__init__() with real CLI detection."""
-
-    def test_construction_succeeds_with_real_cli(self, claude_cli_available: str) -> None:  # noqa: ARG002
-        """ClaudeRunner() should construct without error when CLI is installed."""
-        runner = ClaudeRunner()
-
-        assert runner is not None
-        assert runner.capabilities.found is True
-
-    def test_construction_sets_timeout(self, claude_cli_available: str) -> None:  # noqa: ARG002
-        """ClaudeRunner should inherit a positive timeout from AbstractRunner."""
-        runner = ClaudeRunner()
-
-        assert runner.timeout > 0
-
-
-@pytest.mark.integration
-class TestClaudeRunnerBuildCommand:
-    """Validate command building with real CLI detection."""
-
-    def test_build_command_includes_json_flag(self, claude_runner: ClaudeRunner) -> None:
-        """build_command() should include --output-format json flags."""
-        request = make_prompt_request(cli="claude", prompt="test")
-        command = claude_runner.build_command(request)
-
-        assert "--output-format" in command
-        assert "json" in command
-
-    def test_build_command_includes_prompt_flag(self, claude_runner: ClaudeRunner) -> None:
-        """build_command() should pass the prompt via the -p flag."""
-        request = make_prompt_request(cli="claude", prompt="test")
-        command = claude_runner.build_command(request)
-
-        assert "-p" in command
-
-    def test_build_command_cli_path_is_real(self, claude_runner: ClaudeRunner) -> None:
-        """build_command() CLI path should resolve to an installed binary."""
-        request = make_prompt_request(cli="claude", prompt="test")
-        command = claude_runner.build_command(request)
-
-        assert shutil.which(command[0]) is not None, (
-            f"CLI path {command[0]!r} does not resolve to an installed binary"
-        )
-
-
-@pytest.mark.integration
 @pytest.mark.slow
-class TestClaudeRunnerEndToEnd:
-    """Full Template Method pipeline with real Claude API calls."""
+class TestClaudeRunnerIntegration:
+    """Real CLI binary + real API call tests."""
 
-    async def test_run_simple_prompt_returns_agent_response(
-        self, claude_runner: ClaudeRunner
-    ) -> None:
-        """run() should return an AgentResponse with non-empty output."""
+    async def test_run_returns_valid_response(self, claude_runner: ClaudeRunner) -> None:
+        """run() with real API returns AgentResponse with output and metadata."""
         request = make_prompt_request(cli="claude", prompt=PING_PROMPT)
         response = await claude_runner.run(request)
 
         assert isinstance(response, AgentResponse)
         assert response.cli == "claude"
         assert len(response.output) > 0
-
-    async def test_run_returns_cost_and_timing_metadata(self, claude_runner: ClaudeRunner) -> None:
-        """Claude CLI JSON response includes cost_usd and duration_ms in metadata."""
-        request = make_prompt_request(cli="claude", prompt=PING_PROMPT)
-        response = await claude_runner.run(request)
-
         assert isinstance(response.metadata, dict)
-        # Claude CLI always emits cost and timing in the result object
         assert "cost_usd" in response.metadata
         assert "duration_ms" in response.metadata
 
-    async def test_run_with_model_flag(self, claude_runner: ClaudeRunner) -> None:
-        """run() with an explicit model should succeed and return output."""
-        request = make_prompt_request(
-            cli="claude", prompt=PING_PROMPT, model="claude-haiku-4-5-20251001"
-        )
-        response = await claude_runner.run(request)
-
-        assert isinstance(response, AgentResponse)
-        assert len(response.output) > 0
-
-
-@pytest.mark.integration
-@pytest.mark.slow
-class TestClaudeRunnerErrorPath:
-    """Validate error propagation when the real CLI fails.
-
-    Uses an invalid model name to reliably trigger a non-zero exit from the CLI.
-    This exercises the full error path:
-      server.py → base.py run() → _recover_from_error() or SubprocessError
-
-    Flakiness risk: CLI error messages and exit codes may vary across versions.
-    The assertion is intentionally broad (SubprocessError OR recovered_from_error)
-    to remain valid even if recovery behavior changes.
-    """
-
-    async def test_run_with_invalid_model_raises_or_recovers(
-        self, claude_runner: ClaudeRunner
-    ) -> None:
-        """run() with a nonexistent model should either raise SubprocessError or recover."""
+    async def test_invalid_model_raises_or_recovers(self, claude_runner: ClaudeRunner) -> None:
+        """run() with nonexistent model raises SubprocessError or recovers gracefully."""
         from nexus_mcp.exceptions import SubprocessError
 
         request = make_prompt_request(cli="claude", prompt="ping", model="nonexistent-model-xyz-99")
         try:
             response = await claude_runner.run(request)
-            # Recovery path: error was caught, metadata records it
             assert response.metadata.get("recovered_from_error") is True, (
-                "Expected SubprocessError or recovered_from_error=True for invalid model, "
-                f"got response: {response.output!r}"
+                f"Expected SubprocessError or recovered_from_error=True, got: {response.output!r}"
             )
         except SubprocessError:
-            pass  # Error propagation path — also correct
+            pass

--- a/tests/integration/test_cli_detection.py
+++ b/tests/integration/test_cli_detection.py
@@ -1,35 +1,11 @@
 # tests/integration/test_cli_detection.py
-"""Integration tests for CLI detection functions.
+"""Fallback tests for CLI detection functions (no CLI binary required).
 
-Validates detect_cli(), get_cli_version(), and get_cli_capabilities()
-against the real installed Gemini CLI binary.
+The real CLI detection tests are consolidated into test_gemini_runner.py
+(TestGeminiCLISmoke) to avoid redundancy.
 """
 
-import re
-import subprocess
-
-import pytest
-
-from nexus_mcp.cli_detector import detect_cli, get_cli_capabilities, get_cli_version
-from nexus_mcp.config import get_cli_detection_timeout
-
-
-def _run_version_command(cli_name: str) -> str:
-    """Run '<cli> --version' and return a diagnostic string for assertion messages."""
-    timeout = get_cli_detection_timeout()
-    try:
-        result = subprocess.run(
-            [cli_name, "--version"], capture_output=True, text=True, timeout=timeout
-        )
-        return f"returncode={result.returncode}, stdout={result.stdout!r}, stderr={result.stderr!r}"
-    except FileNotFoundError:
-        return "FileNotFoundError: binary not found"
-    except subprocess.TimeoutExpired:
-        return f"TimeoutExpired: exceeded {timeout}s"
-
-
-# Semver pattern: MAJOR.MINOR.PATCH (optional pre-release suffix handled by parse_version)
-_SEMVER_PATTERN = re.compile(r"^\d+\.\d+\.\d+")
+from nexus_mcp.cli_detector import detect_cli, get_cli_version
 
 
 class TestDetectCLIFallback:
@@ -51,62 +27,3 @@ class TestGetCLIVersionFallback:
         version = get_cli_version("nonexistent_cli_that_does_not_exist_12345")
 
         assert version is None
-
-
-@pytest.mark.integration
-class TestDetectCLIReal:
-    """Validate detect_cli() against real PATH entries."""
-
-    def test_detect_gemini_finds_real_binary(self, gemini_cli_available: str) -> None:
-        """detect_cli('gemini') should find the installed binary and return its path."""
-        result = detect_cli("gemini")
-
-        assert result.found is True
-        assert result.path is not None
-        assert result.path == gemini_cli_available
-
-
-@pytest.mark.integration
-class TestGetCLIVersionReal:
-    """Validate get_cli_version() runs real subprocesses."""
-
-    def test_get_gemini_version_returns_semver(self, gemini_cli_available: str) -> None:  # noqa: ARG002
-        """get_cli_version('gemini') should parse a valid semver from the installed CLI."""
-        version = get_cli_version("gemini")
-
-        assert version is not None, (
-            f"get_cli_version('gemini') returned None — "
-            f"raw output: {_run_version_command('gemini')}"
-        )
-        assert _SEMVER_PATTERN.match(version), f"Expected semver format, got: {version!r}"
-
-
-@pytest.mark.integration
-class TestGetCLICapabilitiesReal:
-    """Validate get_cli_capabilities() with real version data."""
-
-    def test_gemini_capabilities_with_real_version(self, gemini_cli_available: str) -> None:  # noqa: ARG002
-        """get_cli_capabilities() should populate CLICapabilities from real version."""
-        version = get_cli_version("gemini")
-        assert version is not None, (
-            f"get_cli_version('gemini') returned None — "
-            f"raw output: {_run_version_command('gemini')}"
-        )
-        capabilities = get_cli_capabilities("gemini", version)
-
-        assert capabilities.found is True
-        assert isinstance(capabilities.supports_json, bool)
-
-    def test_gemini_modern_version_supports_json(self, gemini_cli_available: str) -> None:  # noqa: ARG002
-        """Installed Gemini CLI should be >= 0.6.0 and support JSON output."""
-        version = get_cli_version("gemini")
-        assert version is not None, (
-            f"get_cli_version('gemini') returned None — "
-            f"raw output: {_run_version_command('gemini')}"
-        )
-        capabilities = get_cli_capabilities("gemini", version)
-
-        # Integration environment must have a modern CLI (>= 0.6.0)
-        assert capabilities.supports_json is True, (
-            f"Expected Gemini CLI >= 0.6.0 to support JSON output, got version: {version}"
-        )

--- a/tests/integration/test_codex_runner.py
+++ b/tests/integration/test_codex_runner.py
@@ -1,14 +1,9 @@
 # tests/integration/test_codex_runner.py
-"""Integration tests for CodexRunner end-to-end pipeline.
+"""Integration tests for CodexRunner with real CLI binary.
 
-Tests exercise the full Template Method pipeline:
-  build_command() → run_subprocess() → parse_output()
-using the real Codex CLI binary.
-
-Tests marked @slow make real API calls and require a valid API key / auth config.
+Minimal set — only tests that require a real CLI binary.
+Command building, NDJSON parsing, and retry logic are covered by unit tests.
 """
-
-import shutil
 
 import pytest
 
@@ -18,73 +13,16 @@ from tests.fixtures import PING_PROMPT, make_prompt_request
 
 
 @pytest.mark.integration
-class TestCodexRunnerConstruction:
-    """Validate CodexRunner.__init__() with real CLI detection."""
-
-    def test_construction_succeeds_with_real_cli(self, codex_cli_available: str) -> None:  # noqa: ARG002
-        """CodexRunner() should construct without error when CLI is installed."""
-        runner = CodexRunner()
-
-        assert runner is not None
-        assert runner.capabilities.found is True
-
-    def test_construction_sets_timeout(self, codex_cli_available: str) -> None:  # noqa: ARG002
-        """CodexRunner should inherit a positive timeout from AbstractRunner."""
-        runner = CodexRunner()
-
-        assert runner.timeout > 0
-
-
-@pytest.mark.integration
-class TestCodexRunnerBuildCommand:
-    """Validate command building with real CLI detection."""
-
-    def test_build_command_includes_json_flag(self, codex_runner: CodexRunner) -> None:
-        """build_command() should include --json flag."""
-        request = make_prompt_request(cli="codex", prompt="test")
-        command = codex_runner.build_command(request)
-
-        assert "--json" in command
-
-    def test_build_command_includes_exec_subcommand(self, codex_runner: CodexRunner) -> None:
-        """build_command() should use 'exec' subcommand."""
-        request = make_prompt_request(cli="codex", prompt="test")
-        command = codex_runner.build_command(request)
-
-        assert "exec" in command
-
-    def test_build_command_cli_path_is_real(self, codex_runner: CodexRunner) -> None:
-        """build_command() CLI path should resolve to an installed binary."""
-        request = make_prompt_request(cli="codex", prompt="test")
-        command = codex_runner.build_command(request)
-
-        assert shutil.which(command[0]) is not None, (
-            f"CLI path {command[0]!r} does not resolve to an installed binary"
-        )
-
-
-@pytest.mark.integration
 @pytest.mark.slow
-class TestCodexRunnerEndToEnd:
-    """Full Template Method pipeline with real Codex API calls."""
+class TestCodexRunnerIntegration:
+    """Real CLI binary + real API call tests."""
 
-    async def test_run_simple_prompt_returns_agent_response(
-        self, codex_runner: CodexRunner
-    ) -> None:
-        """run() should return an AgentResponse with non-empty output."""
+    async def test_run_returns_valid_response(self, codex_runner: CodexRunner) -> None:
+        """run() with real API returns AgentResponse with output and metadata."""
         request = make_prompt_request(cli="codex", prompt=PING_PROMPT)
         response = await codex_runner.run(request)
 
         assert isinstance(response, AgentResponse)
         assert response.cli == "codex"
         assert len(response.output) > 0
-
-    async def test_run_returns_parsed_output(self, codex_runner: CodexRunner) -> None:
-        """run() should populate all AgentResponse fields from parsed NDJSON."""
-        request = make_prompt_request(cli="codex", prompt=PING_PROMPT)
-        response = await codex_runner.run(request)
-
-        assert isinstance(response.output, str)
-        assert isinstance(response.raw_output, str)
         assert isinstance(response.metadata, dict)
-        assert len(response.raw_output) > 0

--- a/tests/integration/test_gemini_runner.py
+++ b/tests/integration/test_gemini_runner.py
@@ -1,126 +1,81 @@
 # tests/integration/test_gemini_runner.py
-"""Integration tests for GeminiRunner end-to-end pipeline.
+"""Integration tests for GeminiRunner with real CLI binary.
 
-Tests exercise the full Template Method pipeline:
-  build_command() → run_subprocess() → parse_output()
-using the real Gemini CLI binary.
+Minimal set of tests that CANNOT be covered by unit/e2e tests (which mock
+at the subprocess boundary). These validate:
 
-Tests marked @slow make real Gemini API calls and require valid credentials.
+1. Real CLI detection + capability resolution
+2. Real API call → valid AgentResponse (happy path)
+3. Real API error behavior (error path)
+
+All other GeminiRunner behavior (command building, JSON parsing, retry logic,
+progress reporting) is fully covered by unit tests in tests/unit/runners/test_gemini.py
+and pipeline tests in tests/unit/test_server_gemini_pipeline.py.
 """
 
-import shutil
+import re
 
 import pytest
 
+from nexus_mcp.cli_detector import detect_cli, get_cli_capabilities, get_cli_version
 from nexus_mcp.runners.gemini import GeminiRunner
 from nexus_mcp.types import AgentResponse
 from tests.fixtures import PING_PROMPT, make_prompt_request
 
+_SEMVER_PATTERN = re.compile(r"^\d+\.\d+\.\d+")
+
 
 @pytest.mark.integration
-class TestGeminiRunnerConstruction:
-    """Validate GeminiRunner.__init__() with real CLI detection."""
+class TestGeminiCLISmoke:
+    """Validate real CLI detection, version parsing, and capability resolution."""
 
-    def test_construction_succeeds_with_real_cli(self, gemini_cli_available: str) -> None:  # noqa: ARG002
-        """GeminiRunner() should construct without error when CLI is installed."""
-        runner = GeminiRunner()
+    def test_cli_detected_with_json_support(self, gemini_cli_available: str) -> None:
+        """detect_cli finds binary, version parses as semver, supports_json is True."""
+        cli_info = detect_cli("gemini")
+        assert cli_info.found is True
+        assert cli_info.path == gemini_cli_available
 
-        assert runner is not None
-        assert runner.capabilities.found is True
+        version = get_cli_version("gemini")
+        assert version is not None, "get_cli_version returned None"
+        assert _SEMVER_PATTERN.match(version), f"Expected semver, got: {version!r}"
 
-    def test_construction_sets_timeout(self, gemini_cli_available: str) -> None:  # noqa: ARG002
-        """GeminiRunner should inherit a positive timeout from AbstractRunner."""
-        runner = GeminiRunner()
-
-        assert runner.timeout > 0
+        capabilities = get_cli_capabilities("gemini", version)
+        assert capabilities.found is True
+        assert capabilities.supports_json is True, (
+            f"Gemini CLI {version} does not support JSON — requires >= 0.6.0"
+        )
 
 
 @pytest.mark.integration
 @pytest.mark.slow
-class TestGeminiRunnerEndToEnd:
-    """Full Template Method pipeline with real Gemini API calls."""
+class TestGeminiHappyPath:
+    """Real API call → valid AgentResponse."""
 
-    async def test_run_simple_prompt_returns_agent_response(
-        self, gemini_runner: GeminiRunner
-    ) -> None:
-        """run() should return an AgentResponse with non-empty output."""
+    async def test_run_returns_valid_response(self, gemini_runner: GeminiRunner) -> None:
+        """run() with real API returns AgentResponse with output and metadata."""
         request = make_prompt_request(prompt=PING_PROMPT)
         response = await gemini_runner.run(request)
 
         assert isinstance(response, AgentResponse)
         assert response.cli == "gemini"
         assert len(response.output) > 0
-
-    async def test_run_returns_json_parsed_output(self, gemini_runner: GeminiRunner) -> None:
-        """run() should populate all AgentResponse fields from parsed JSON."""
-        request = make_prompt_request(prompt=PING_PROMPT)
-        response = await gemini_runner.run(request)
-
-        assert isinstance(response.output, str)
-        assert isinstance(response.raw_output, str)
         assert isinstance(response.metadata, dict)
-        # raw_output should contain the original JSON from the CLI
-        assert len(response.raw_output) > 0
-
-    async def test_run_with_model_flag(self, gemini_runner: GeminiRunner) -> None:
-        """run() with an explicit model should succeed and return output."""
-        request = make_prompt_request(prompt=PING_PROMPT, model="gemini-2.5-flash")
-        response = await gemini_runner.run(request)
-
-        assert isinstance(response, AgentResponse)
-        assert len(response.output) > 0
 
 
 @pytest.mark.integration
 @pytest.mark.slow
-class TestGeminiRunnerErrorPath:
-    """Validate error propagation when the real CLI fails.
+class TestGeminiErrorPath:
+    """Real API error behavior with invalid model."""
 
-    Uses an invalid model name to reliably trigger a non-zero exit from the CLI.
-    This exercises the full error path:
-      server.py:69 → base.py run() → _recover_from_error() or SubprocessError
-
-    Flakiness risk: CLI error messages and exit codes may vary across versions.
-    The assertion is intentionally broad (SubprocessError OR recovered_from_error)
-    to remain valid even if recovery behavior changes.
-    """
-
-    async def test_run_with_invalid_model_raises_or_recovers(
-        self, gemini_runner: GeminiRunner
-    ) -> None:
-        """run() with a nonexistent model should either raise SubprocessError or recover."""
+    async def test_invalid_model_raises_or_recovers(self, gemini_runner: GeminiRunner) -> None:
+        """run() with nonexistent model raises SubprocessError or recovers gracefully."""
         from nexus_mcp.exceptions import SubprocessError
 
         request = make_prompt_request(prompt="ping", model="nonexistent-model-xyz-99")
         try:
             response = await gemini_runner.run(request)
-            # Recovery path: error was caught, metadata records it
             assert response.metadata.get("recovered_from_error") is True, (
-                "Expected SubprocessError or recovered_from_error=True for invalid model, "
-                f"got response: {response.output!r}"
+                f"Expected SubprocessError or recovered_from_error=True, got: {response.output!r}"
             )
         except SubprocessError:
             pass  # Error propagation path — also correct
-
-
-@pytest.mark.integration
-class TestGeminiRunnerBuildCommand:
-    """Validate command building uses real capability detection."""
-
-    def test_build_command_includes_json_flag(self, gemini_runner: GeminiRunner) -> None:
-        """build_command() should include --output-format json for modern CLI versions."""
-        request = make_prompt_request(prompt="test")
-        command = gemini_runner.build_command(request)
-
-        assert "--output-format" in command
-        assert "json" in command
-
-    def test_build_command_cli_path_is_real(self, gemini_runner: GeminiRunner) -> None:
-        """build_command() CLI path should resolve to an installed binary."""
-        request = make_prompt_request(prompt="test")
-        command = gemini_runner.build_command(request)
-
-        # command[0] is the CLI path — verify it resolves to a real binary
-        assert shutil.which(command[0]) is not None, (
-            f"CLI path {command[0]!r} does not resolve to an installed binary"
-        )

--- a/tests/integration/test_opencode_runner.py
+++ b/tests/integration/test_opencode_runner.py
@@ -1,17 +1,9 @@
 # tests/integration/test_opencode_runner.py
-"""Integration tests for OpenCodeRunner end-to-end pipeline.
+"""Integration tests for OpenCodeRunner with real CLI binary.
 
-Tests exercise the full Template Method pipeline:
-  build_command() → run_subprocess() → parse_output()
-using the real OpenCode CLI binary.
-
-All tests are skipped when opencode CLI is not installed.
-Tests marked @slow make real API calls and require valid auth config.
-
-Output format verified against OpenCode CLI v1.2.20 (NDJSON events).
+Minimal set — only tests that require a real CLI binary.
+Command building, NDJSON parsing, and retry logic are covered by unit tests.
 """
-
-import shutil
 
 import pytest
 
@@ -21,81 +13,15 @@ from tests.fixtures import PING_PROMPT, make_prompt_request
 
 
 @pytest.mark.integration
-class TestOpenCodeRunnerConstruction:
-    """Validate OpenCodeRunner.__init__() with real CLI detection."""
-
-    def test_construction_succeeds_with_real_cli(self, opencode_cli_available: str) -> None:  # noqa: ARG002
-        """OpenCodeRunner() should construct without error when CLI is installed."""
-        runner = OpenCodeRunner()
-
-        assert runner is not None
-        assert runner.capabilities.found is True
-
-    def test_construction_sets_timeout(self, opencode_cli_available: str) -> None:  # noqa: ARG002
-        """OpenCodeRunner should inherit a positive timeout from AbstractRunner."""
-        runner = OpenCodeRunner()
-
-        assert runner.timeout > 0
-
-
-@pytest.mark.integration
-class TestOpenCodeRunnerBuildCommand:
-    """Validate command building with real CLI detection."""
-
-    def test_build_command_includes_json_flag(self, opencode_runner: OpenCodeRunner) -> None:
-        """build_command() should include --format json flags."""
-        request = make_prompt_request(cli="opencode", prompt="test")
-        command = opencode_runner.build_command(request)
-
-        assert "--format" in command
-        assert "json" in command
-
-    def test_build_command_includes_prompt_flag(self, opencode_runner: OpenCodeRunner) -> None:
-        """build_command() should include the prompt as a positional argument."""
-        request = make_prompt_request(cli="opencode", prompt="test")
-        command = opencode_runner.build_command(request)
-
-        assert "test" in command
-
-    def test_build_command_cli_path_is_real(self, opencode_runner: OpenCodeRunner) -> None:
-        """build_command() CLI path should resolve to an installed binary."""
-        request = make_prompt_request(cli="opencode", prompt="test")
-        command = opencode_runner.build_command(request)
-
-        assert shutil.which(command[0]) is not None, (
-            f"CLI path {command[0]!r} does not resolve to an installed binary"
-        )
-
-
-@pytest.mark.integration
 @pytest.mark.slow
-class TestOpenCodeRunnerEndToEnd:
-    """Full Template Method pipeline with real OpenCode API calls."""
+class TestOpenCodeRunnerIntegration:
+    """Real CLI binary + real API call tests."""
 
-    async def test_run_simple_prompt_returns_agent_response(
-        self, opencode_runner: OpenCodeRunner
-    ) -> None:
-        """run() should return an AgentResponse with non-empty output."""
+    async def test_run_returns_valid_response(self, opencode_runner: OpenCodeRunner) -> None:
+        """run() with real API returns AgentResponse with output and metadata."""
         request = make_prompt_request(cli="opencode", prompt=PING_PROMPT)
         response = await opencode_runner.run(request)
 
         assert isinstance(response, AgentResponse)
         assert response.cli == "opencode"
         assert len(response.output) > 0
-
-    async def test_run_default_mode_restricts_tools(self, opencode_runner: OpenCodeRunner) -> None:
-        """run() with default mode should succeed (no tool restriction flags available)."""
-        request = make_prompt_request(cli="opencode", prompt=PING_PROMPT, execution_mode="default")
-        response = await opencode_runner.run(request)
-
-        assert isinstance(response, AgentResponse)
-        assert len(response.output) > 0
-
-    async def test_run_schema_discovery(self, opencode_runner: OpenCodeRunner) -> None:
-        """Verify raw_output is non-empty and format matches NDJSON event stream."""
-        request = make_prompt_request(cli="opencode", prompt=PING_PROMPT)
-        response = await opencode_runner.run(request)
-
-        # Print raw output for empirical format verification
-        print(f"\nOpenCode raw_output:\n{response.raw_output!r}")
-        assert response.raw_output, "raw_output should not be empty"

--- a/tests/integration/test_server_pipeline.py
+++ b/tests/integration/test_server_pipeline.py
@@ -1,21 +1,15 @@
 # tests/integration/test_server_pipeline.py
-"""Integration tests for the full MCP server pipeline.
+"""Smoke tests for server-level behavior (no CLI binary required).
 
-Tests exercise prompt() from server.py using the real Gemini CLI, and
-verify server instructions are populated. Only Context is mocked for
-progress assertions — all other components are real.
-
-Imports the raw functions (not MCP-wrapped FunctionTool), matching the
-pattern established in tests/unit/test_server.py.
+The full prompt() pipeline with real CLI is covered by test_gemini_runner.py
+(TestGeminiHappyPath). Progress reporting is covered by unit tests in
+tests/unit/test_server_progress.py.
 """
-
-from unittest.mock import AsyncMock
 
 import pytest
 from fastmcp.exceptions import ToolError
 
 from nexus_mcp.server import prompt
-from tests.fixtures import PING_PROMPT
 
 
 class TestServerInstructionsSmokeTest:
@@ -39,41 +33,3 @@ class TestServerPromptValidation:
                 cli="nonexistent_agent_12345",
                 prompt="test",
             )
-
-
-@pytest.mark.integration
-class TestServerPromptPipeline:
-    """Full prompt() pipeline tests with real CLI execution."""
-
-    @pytest.mark.slow
-    async def test_prompt_returns_string(self, gemini_cli_available: str) -> None:  # noqa: ARG002
-        """prompt() should return a non-empty string from real CLI output."""
-        result = await prompt(
-            cli="gemini",
-            prompt=PING_PROMPT,
-        )
-
-        assert isinstance(result, str)
-        assert len(result) > 0
-
-    @pytest.mark.slow
-    async def test_prompt_reports_progress(self, gemini_cli_available: str, ctx: AsyncMock) -> None:  # noqa: ARG002
-        """prompt() reports runner-level progress (attempt + step-level calls).
-
-        Single-task prompt uses unwrapped emitter: runner's progress/total pass
-        through directly. Expect 5 calls: 1 attempt + 4 steps (happy path skips
-        error-check step 3).
-        """
-        await prompt(
-            cli="gemini",
-            prompt=PING_PROMPT,
-            ctx=ctx,
-        )
-
-        assert ctx.report_progress.await_count == 5
-        # First call is attempt-level
-        first_msg = ctx.report_progress.call_args_list[0].kwargs["message"]
-        assert first_msg.startswith("Attempt ")
-        # No task wrapper prefix (unwrapped emitter for single-task)
-        messages = [c.kwargs["message"] for c in ctx.report_progress.call_args_list]
-        assert all("Task '" not in m for m in messages)


### PR DESCRIPTION
## Summary

Reduces all runner integration tests to the absolute minimum that requires real CLI binaries. Command building, JSON/NDJSON parsing, retry logic, and progress reporting are fully covered by unit and e2e tests.

**Before:** 31 integration tests | **After:** 11 tests (-65%)

### What remains per runner

| Runner | Tests | What they verify |
|--------|-------|-----------------|
| Gemini | 3 | CLI smoke (detection+version+JSON capability), happy path, error path |
| Claude | 2 | Happy path (with cost/timing metadata), error path |
| Codex | 1 | Happy path |
| OpenCode | 1 | Happy path |
| Non-CLI | 4 | CLI detection fallbacks, server smoke tests |

### What was removed

All tests already covered by unit/e2e tests that mock at the subprocess boundary:
- Construction tests (unit runner init tests cover this)
- `build_command` tests (exact duplicates of unit tests)
- Duplicate end-to-end tests (JSON parsing, model flags, progress reporting)
- CLI detection tests consolidated into single Gemini CLI smoke test

## Test plan

- [x] 1100 unit + e2e tests passing (unchanged)
- [x] 11 integration tests passing (246s)
- [x] Pre-commit hooks: all passing