### PR TITLE
fix: resolve YAML parsing errors in cool-down workflows

### DIFF
--- a/.github/workflows/dependency-cooldown-gate.yml
+++ b/.github/workflows/dependency-cooldown-gate.yml
@@ -1,4 +1,4 @@
-name: Dependency Cool-Down
+name: Dependency Cool-Down Gate
 
 on:
   pull_request:
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  gate:
+  set-pending-status:
     if: >
       github.actor == 'dependabot[bot]' ||
       github.actor == 'renovate[bot]'

--- a/.github/workflows/dependency-cooldown-scan.yml
+++ b/.github/workflows/dependency-cooldown-scan.yml
@@ -267,13 +267,14 @@ jobs:
               DEPS="(no dependencies extracted from diff)"
             fi
 
-            # Build comment
+            # Build comment — table headers/separators stored in variables
+            # to avoid bare | at column 0 which breaks YAML block scalar parsing
             TOTAL=$((GHSA_TOTAL + OSV_TOTAL))
             if [ "$TOTAL" -gt 0 ]; then
               RESULTS_HEADER="**${TOTAL} advisory/ies found** — review before merging."
-              RESULTS_TABLE="| ID | Severity | Summary | Source |
-|----|----------|---------|--------|
-${SCAN_RESULTS}"
+              TABLE_HDR="| ID | Severity | Summary | Source |"
+              TABLE_SEP="|----|----------|---------|--------|"
+              RESULTS_TABLE="$(printf '%s\n%s\n%s' "$TABLE_HDR" "$TABLE_SEP" "$SCAN_RESULTS")"
               RESULTS_FOOTER="> Review the advisories above before deciding to merge."
             elif [ -n "$HAS_ERROR" ]; then
               # Do NOT post comment or update status on errors.
@@ -282,25 +283,22 @@ ${SCAN_RESULTS}"
               continue
             else
               RESULTS_HEADER="No known exploits found in GHSA or OSV databases."
-              RESULTS_TABLE="| Source | Vulnerabilities |
-|--------|----------------|
-| GitHub Advisory (GHSA) | 0 found |
-| OSV.dev | 0 found |"
+              TABLE_HDR="| Source | Vulnerabilities |"
+              TABLE_SEP="|--------|----------------|"
+              ROW1="| GitHub Advisory (GHSA) | 0 found |"
+              ROW2="| OSV.dev | 0 found |"
+              RESULTS_TABLE="$(printf '%s\n%s\n%s\n%s' "$TABLE_HDR" "$TABLE_SEP" "$ROW1" "$ROW2")"
               RESULTS_FOOTER="> This PR is now eligible for manual review and merge."
             fi
 
-            COMMENT_BODY="## Dependency Security Scan (5-Day Cool-Down Complete)
-
-**PR age:** ${AGE_DAYS} days, ${AGE_HOURS} hours
-**Packages scanned:** ${DEPS}
-
-### Results
-
-${RESULTS_HEADER}
-
-${RESULTS_TABLE}
-
-${RESULTS_FOOTER}"
+            COMMENT_BODY="$(printf '%s\n\n%s\n%s\n\n%s\n\n%s\n\n%s\n\n%s' \
+              "## Dependency Security Scan (5-Day Cool-Down Complete)" \
+              "**PR age:** ${AGE_DAYS} days, ${AGE_HOURS} hours" \
+              "**Packages scanned:** ${DEPS}" \
+              "### Results" \
+              "$RESULTS_HEADER" \
+              "$RESULTS_TABLE" \
+              "$RESULTS_FOOTER")"
 
             # Post comment and set status to success (human decides on exploits)
             gh pr comment "$PR_NUMBER" \

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,6 @@ repos:
 
       # Syntax validation
       - id: check-yaml
-        exclude: dependency-cooldown-scan\.yml
       - id: check-toml  # Validates pyproject.toml
       - id: check-ast   # Validates Python syntax
 


### PR DESCRIPTION
## Summary

- Fix YAML parsing failure in `dependency-cooldown-scan.yml` that caused GitHub Actions to error on every push
- Move markdown table pipes (`|`) into shell variables so they don't appear at YAML column 0 (which both PyYAML and GitHub's parser interpret as block scalar indicators)
- Remove the `check-yaml` exclusion from `.pre-commit-config.yaml` (no longer needed)
- Rename gate workflow name/job to avoid check name collision with the commit status context

## Root Cause

The scan workflow embedded markdown tables directly in multi-line shell string assignments inside a YAML `run: |` block. Lines like `|----|----------|---------|--------|` at column 0 are invalid YAML — the `|` is interpreted as a block scalar indicator, not as string content.

## Test plan

- [x] All 6 workflow YAML files validate with PyYAML
- [x] `check-yaml` pre-commit hook passes without exclusions
- [ ] GitHub Actions parses the workflow successfully on push