### PR TITLE
chore: Docker polish — security hardening, workspace config, setup guide

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.github
+.worktrees
+tests
+docs
+*.md
+.env
+.env.*
+__pycache__
+*.pyc
+.mypy_cache
+.ruff_cache
+.pytest_cache
+.coverage
+htmlcov

--- a/.env.example
+++ b/.env.example
@@ -1,13 +1,42 @@
-# OpenCode Server authentication
+# === Workspace ===
+# Project directory to mount into the OpenCode container
+PROJECT_DIR=.
+
+# === OpenCode server credentials ===
 OPENCODE_SERVER_PASSWORD=nexus
 OPENCODE_SERVER_USERNAME=opencode
+# OPENCODE_PORT=4096
 
-# Provider API keys (uncomment and set as needed)
-# ANTHROPIC_API_KEY=
-# OPENAI_API_KEY=
-# GOOGLE_API_KEY=
-
-# nexus-mcp connection settings (match docker-compose values)
+# === nexus-mcp connection (must match above) ===
 NEXUS_OPENCODE_SERVER_URL=http://localhost:4096
 NEXUS_OPENCODE_SERVER_PASSWORD=nexus
 NEXUS_OPENCODE_SERVER_USERNAME=opencode
+
+# === Provider API keys (OpenCode auto-detects these) ===
+# Alternative: docker exec opencode-server opencode auth login
+#
+# Popular providers:
+# ANTHROPIC_API_KEY=
+# OPENAI_API_KEY=
+# GOOGLE_API_KEY=
+# OPENROUTER_API_KEY=
+# MISTRAL_API_KEY=
+# DEEPSEEK_API_KEY=
+#
+# Additional providers:
+# GROQ_API_KEY=
+# XAI_API_KEY=
+# COHERE_API_KEY=
+# CEREBRAS_API_KEY=
+# FIREWORKS_API_KEY=
+# PERPLEXITY_API_KEY=
+# TOGETHER_API_KEY=
+# HUGGINGFACE_API_KEY=
+# DEEPINFRA_API_KEY=
+#
+# Cloud providers:
+# AWS_ACCESS_KEY_ID=
+# AWS_SECRET_ACCESS_KEY=
+# AWS_REGION=
+# AZURE_API_KEY=
+# AZURE_RESOURCE_NAME=

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM ghcr.io/anomalyco/opencode:latest
+FROM ghcr.io/anomalyco/opencode:1.3.13
 ENTRYPOINT ["opencode", "serve"]
 CMD ["--hostname", "0.0.0.0", "--port", "4096"]

--- a/README.md
+++ b/README.md
@@ -194,6 +194,35 @@ uv run python -m nexus_mcp
 
 </details>
 
+<details>
+<summary><h3>OpenCode Server (Docker)</h3></summary>
+
+Run an isolated [OpenCode](https://opencode.ai) server for HTTP-based agent execution alongside the CLI runner. Provides session management, file search, permissions, and 38 additional MCP tools when the server is healthy.
+
+**Quick start:**
+
+1. Copy `.env.example` to `.env` and set `PROJECT_DIR` to your project path:
+   ```bash
+   cp .env.example .env
+   # Edit .env: set PROJECT_DIR=/path/to/your/project
+   ```
+2. Start the server:
+   ```bash
+   docker compose up -d
+   ```
+3. Authenticate with your provider:
+   ```bash
+   docker exec -it opencode-server opencode auth login
+   ```
+4. Verify the server is healthy:
+   ```bash
+   curl -u opencode:nexus http://localhost:4096/global/health
+   ```
+
+The server binds to `127.0.0.1` (localhost only) by default for security. See [docs/opencode-server-setup.md](docs/opencode-server-setup.md) for the full guide including remote access, multi-project setup, and network security.
+
+</details>
+
 ## Usage
 
 Once nexus-mcp is configured in your MCP client, your AI assistant automatically sees its tools.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,23 +2,24 @@ services:
   opencode-server:
     build: .
     ports:
-      - "4096:4096"
+      # SECURITY: Bind to 127.0.0.1 (localhost only). The OpenCode server exposes
+      # file read/write, shell execution, and provider credentials behind Basic Auth.
+      # Changing to 0.0.0.0 exposes the server to your entire network.
+      # See docs/opencode-server-setup.md for remote access guidance.
+      - "127.0.0.1:${OPENCODE_PORT:-4096}:4096"
     volumes:
-      - .:/workspace
+      - ${PROJECT_DIR:-.}:/workspace
       - opencode-data:/root/.local/share/opencode
-      - ./opencode.json:/workspace/opencode.json:ro
-    environment:
-      - OPENCODE_SERVER_PASSWORD=${OPENCODE_SERVER_PASSWORD:-nexus}
-      - OPENCODE_SERVER_USERNAME=${OPENCODE_SERVER_USERNAME:-opencode}
-      - ANTHROPIC_API_KEY
-      - OPENAI_API_KEY
-      - GOOGLE_API_KEY
-      - XAI_API_KEY
-      - GROQ_API_KEY
-      - AWS_ACCESS_KEY_ID
-      - AWS_SECRET_ACCESS_KEY
-      - AWS_REGION
+    env_file:
+      - path: .env
+        required: false
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:4096/global/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
 
 volumes:
   opencode-data:

--- a/docs/opencode-server-setup.md
+++ b/docs/opencode-server-setup.md
@@ -1,0 +1,252 @@
+# OpenCode Server Setup Guide
+
+Run an isolated OpenCode server via Docker for HTTP-based agent execution. This enables session management, file search, workspace tools, permissions, and questions — capabilities not available through the CLI subprocess runner.
+
+## Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/) (v2+)
+- An API key for at least one LLM provider (Anthropic, OpenAI, Google, etc.)
+
+## Quick Start
+
+```bash
+# 1. Copy the environment template
+cp .env.example .env
+
+# 2. Set your project directory (the directory OpenCode will work in)
+#    Edit .env and change PROJECT_DIR to your project path:
+#    PROJECT_DIR=/path/to/your/project
+
+# 3. Start the server
+docker compose up -d
+
+# 4. Authenticate with your provider
+docker exec -it opencode-server opencode auth login
+
+# 5. Verify health
+curl -u opencode:nexus http://localhost:4096/global/health
+# Expected: {"healthy":true,"version":"..."}
+```
+
+## Authentication
+
+Two methods, both using OpenCode's native auth system:
+
+### Interactive (recommended for local development)
+
+```bash
+docker exec -it opencode-server opencode auth login
+```
+
+This launches OpenCode's built-in auth flow. Credentials are saved to the persistent volume (`opencode-data`) and survive container restarts.
+
+### Environment variables (for CI/headless)
+
+Set provider API keys in `.env`:
+
+```env
+ANTHROPIC_API_KEY=sk-ant-...
+OPENAI_API_KEY=sk-...
+```
+
+OpenCode auto-detects these standard environment variables. See `.env.example` for the full list of supported providers (20+).
+
+## Workspace Configuration
+
+### One container per project
+
+The `PROJECT_DIR` variable in `.env` controls which directory is mounted as `/workspace` inside the container:
+
+```env
+PROJECT_DIR=/Users/you/Documents/github/my-app
+```
+
+OpenCode operates on files inside `/workspace`. Changing `PROJECT_DIR` requires restarting the container:
+
+```bash
+# Edit .env with new PROJECT_DIR, then:
+docker compose restart
+```
+
+### Multiple projects simultaneously
+
+Run separate containers on different ports:
+
+```bash
+# Terminal 1: project A on port 4096
+PROJECT_DIR=/path/to/project-a OPENCODE_PORT=4096 docker compose up -d
+
+# Terminal 2: project B on port 4097
+PROJECT_DIR=/path/to/project-b OPENCODE_PORT=4097 docker compose up -d
+```
+
+Configure nexus-mcp to connect to the appropriate port per project.
+
+## Network Security
+
+### Default: localhost only
+
+The Docker port binding defaults to `127.0.0.1` (localhost only):
+
+```yaml
+ports:
+  - "127.0.0.1:${OPENCODE_PORT:-4096}:4096"
+```
+
+This means **only processes on the same machine** can connect to the OpenCode server. This includes nexus-mcp, curl, and your browser — but not other devices on your network.
+
+### Why localhost binding matters
+
+The OpenCode server exposes powerful capabilities behind HTTP Basic Auth:
+
+- **File read/write** — read and modify any file in your mounted project
+- **Shell execution** — run arbitrary commands in the project context
+- **Provider credentials** — access stored API keys for all configured providers
+- **Session control** — create, abort, and manage coding sessions
+
+The default password (`nexus`) is intentionally simple for local development. This is safe when the server is only reachable from localhost.
+
+### Remote access (VPS / cloud)
+
+If you need to access the server from another machine (e.g., running Docker on a VPS):
+
+> **WARNING:** Changing `127.0.0.1` to `0.0.0.0` exposes the server to your entire network. Anyone who can reach the port gets full access to your project files, shell execution, and provider API keys.
+
+**Required mitigations:**
+
+1. **Change the default password** to a strong, unique value:
+   ```env
+   OPENCODE_SERVER_PASSWORD=your-strong-random-password-here
+   ```
+
+2. **Use a reverse proxy with TLS** — never expose plain HTTP Basic Auth over the network:
+   ```
+   Internet → Nginx/Traefik (HTTPS) → 127.0.0.1:4096 (HTTP, container)
+   ```
+
+3. **Restrict access** via firewall rules or VPN:
+   ```bash
+   # Example: only allow your IP
+   ufw allow from YOUR_IP to any port 4096
+   ufw deny 4096
+   ```
+
+4. **Prefer SSH tunneling** over direct exposure:
+   ```bash
+   # From your local machine:
+   ssh -L 4096:localhost:4096 user@your-vps
+   # Then connect to http://localhost:4096 locally
+   ```
+
+## Connecting nexus-mcp
+
+### Environment variables
+
+Set in `.env` (must match the Docker container credentials):
+
+```env
+NEXUS_OPENCODE_SERVER_URL=http://localhost:4096
+NEXUS_OPENCODE_SERVER_PASSWORD=nexus
+NEXUS_OPENCODE_SERVER_USERNAME=opencode
+```
+
+### MCP client configuration
+
+Add the OpenCode server env vars to your MCP client config. Example for Claude Code (`.mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "nexus-mcp": {
+      "command": "uvx",
+      "args": ["nexus-mcp"],
+      "env": {
+        "NEXUS_OPENCODE_SERVER_URL": "http://localhost:4096",
+        "NEXUS_OPENCODE_SERVER_PASSWORD": "nexus",
+        "NEXUS_OPENCODE_SERVER_USERNAME": "opencode"
+      }
+    }
+  }
+}
+```
+
+When the server is configured and healthy, nexus-mcp automatically registers 38 additional tools and 18 resources for workspace operations, session management, permissions, and questions.
+
+## Health Check
+
+The container includes a built-in health check that polls `GET /global/health` every 30 seconds.
+
+Check health manually:
+
+```bash
+# Via curl
+curl -u opencode:nexus http://localhost:4096/global/health
+
+# Via Docker
+docker inspect --format='{{.State.Health.Status}}' opencode-server
+```
+
+The nexus-mcp `nexus://opencode` resource also reports server health status.
+
+## Troubleshooting
+
+### Container won't start
+
+```bash
+docker compose logs opencode-server
+```
+
+Common causes:
+- **Port conflict** — another service on port 4096. Change `OPENCODE_PORT` in `.env`.
+- **Image pull failure** — check network connectivity and Docker Hub access.
+
+### Auth fails (401)
+
+The password in `.env` must match between OpenCode server and nexus-mcp:
+- `OPENCODE_SERVER_PASSWORD` → used by the Docker container
+- `NEXUS_OPENCODE_SERVER_PASSWORD` → used by nexus-mcp to connect
+
+If they don't match, nexus-mcp gets HTTP 401 and logs "OpenCode server returned 401".
+
+### Files not visible to OpenCode
+
+Check `PROJECT_DIR` in `.env`. It must be an absolute path to your project:
+
+```bash
+# Wrong (mounts the nexus-mcp directory, not your project)
+PROJECT_DIR=.
+
+# Right
+PROJECT_DIR=/Users/you/Documents/github/my-app
+```
+
+After changing `PROJECT_DIR`, restart: `docker compose restart`
+
+### Health check failing
+
+```bash
+# Check if server is starting up (allow 10-30 seconds)
+docker compose logs --tail 20 opencode-server
+
+# Check health check status
+docker inspect --format='{{json .State.Health}}' opencode-server | python3 -m json.tool
+```
+
+If the server logs show it's running but health check fails, the server may need more startup time. The health check has a 10-second `start_period` grace.
+
+## Upgrading
+
+To upgrade OpenCode:
+
+1. Edit `Dockerfile` — change the version tag:
+   ```dockerfile
+   FROM ghcr.io/anomalyco/opencode:1.4.0
+   ```
+
+2. Rebuild and restart:
+   ```bash
+   docker compose build --no-cache
+   docker compose up -d
+   ```
+
+Your auth credentials and session data persist in the `opencode-data` volume across upgrades.


### PR DESCRIPTION
## Summary

- Pin OpenCode Docker image to `1.3.13` (was unpinned `latest`)
- Bind port to `127.0.0.1` (localhost only) — prevents network exposure of file read/write, shell execution, and provider credentials behind Basic Auth
- Add Docker health check (`GET /global/health`, 30s interval)
- Replace individual env var enumeration with `env_file: .env`
- Add `PROJECT_DIR` for configurable workspace mount (one container per project)
- Remove nonexistent `opencode.json` bind mount
- Add `.dockerignore` to exclude .git, tests, docs from build context
- Rewrite `.env.example` with grouped sections and full provider list (20+ OpenCode-native env vars)
- Add OpenCode Server quick start section to README
- Add comprehensive setup guide (`docs/opencode-server-setup.md`) with network security documentation

### Security note

The `127.0.0.1` port binding is the most important change. Without it, Docker defaults to `0.0.0.0` which exposes the server to the entire network. The setup guide includes a dedicated "Network Security" section with warnings and required mitigations for remote access (strong password, TLS reverse proxy, firewall/VPN, SSH tunneling).

## Test plan

- [x] `docker compose config` validates successfully
- [x] Pre-commit hooks pass on all files
- [ ] `docker compose up -d` starts healthy container
- [ ] `curl -u opencode:nexus http://localhost:4096/global/health` returns `{"healthy":true}`
- [ ] `docker exec -it opencode-server opencode auth login` completes successfully
- [ ] Verify port is NOT accessible from another machine on the network