### PR TITLE
fix: upgrade fastmcp to 3.2.0 (CVE-2026-32871, CVE-2026-27124)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 ]
 requires-python = ">=3.13"
 dependencies = [
-    "fastmcp[tasks]>=3.1.0,<4.0",
+    "fastmcp[tasks]>=3.2.0,<4.0",
     "httpx>=0.28.1,<0.29",
     "packaging>=26.0",
     "pydantic>=2.12.5,<3.0",

--- a/src/nexus_mcp/middleware.py
+++ b/src/nexus_mcp/middleware.py
@@ -16,7 +16,7 @@ from time import perf_counter
 import mcp.types as mt
 from fastmcp.exceptions import ToolError
 from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
-from fastmcp.tools.tool import ToolResult
+from fastmcp.tools import ToolResult
 from pydantic import ValidationError
 
 from nexus_mcp.correlation import correlation_id, set_correlation_id

--- a/uv.lock
+++ b/uv.lock
@@ -455,7 +455,7 @@ lua = [
 
 [[package]]
 name = "fastmcp"
-version = "3.1.1"
+version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -480,9 +480,9 @@ dependencies = [
     { name = "watchfiles" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/83/c95d3bf717698a693eccb43e137a32939d2549876e884e246028bff6ecce/fastmcp-3.1.1.tar.gz", hash = "sha256:db184b5391a31199323766a3abf3a8bfbb8010479f77eca84c0e554f18655c48", size = 17347644, upload-time = "2026-03-14T19:12:20.235Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/32/4f1b2cfd7b50db89114949f90158b1dcc2c92a1917b9f57c0ff24e47a2f4/fastmcp-3.2.0.tar.gz", hash = "sha256:d4830b8ffc3592d3d9c76dc0f398904cf41f04910e41a0de38cc1004e0903bef", size = 26318581, upload-time = "2026-03-30T20:25:37.692Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/ea/570122de7e24f72138d006f799768e14cc1ccf7fcb22b7750b2bd276c711/fastmcp-3.1.1-py3-none-any.whl", hash = "sha256:8132ba069d89f14566b3266919d6d72e2ec23dd45d8944622dca407e9beda7eb", size = 633754, upload-time = "2026-03-14T19:12:22.736Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/67/684fa2d2de1e7504549d4ca457b4f854ccec3cd3be03bd86b33b599fbf58/fastmcp-3.2.0-py3-none-any.whl", hash = "sha256:e71aba3df16f86f546a4a9e513261d3233bcc92bef0dfa647bac3fa33623f681", size = 705550, upload-time = "2026-03-30T20:25:35.499Z" },
 ]
 
 [package.optional-dependencies]
@@ -961,7 +961,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fastmcp", extras = ["tasks"], specifier = ">=3.1.0,<4.0" },
+    { name = "fastmcp", extras = ["tasks"], specifier = ">=3.2.0,<4.0" },
     { name = "httpx", specifier = ">=0.28.1,<0.29" },
     { name = "packaging", specifier = ">=26.0" },
     { name = "pydantic", specifier = ">=2.12.5,<3.0" },


### PR DESCRIPTION
## Summary

- Bump `fastmcp[tasks]` minimum from `>=3.1.0` to `>=3.2.0`
- Fix import path: `fastmcp.tools.tool` renamed to `fastmcp.tools.base` in 3.2.0 (use re-export from `fastmcp.tools`)

### CVEs resolved

| CVE | Severity | Description |
|-----|----------|-------------|
| CVE-2026-32871 | **CRITICAL** | SSRF & Path Traversal in OpenAPIProvider |
| CVE-2026-27124 | **HIGH** | Missing consent verification in OAuth Proxy |

### Unblocks

- PR #132 (Docker polish) — Trivy scan was failing on fastmcp 3.1.1
- PR #131 (TruffleHog update) — same Trivy failure

## Test plan

- [x] 1248 tests pass, 96.93% coverage
- [x] mypy clean (fixed `fastmcp.tools.tool` → `fastmcp.tools` import)
- [x] ruff clean
- [x] Pre-commit hooks pass
- [ ] Trivy CI scan passes with fastmcp 3.2.0