### PR TITLE
chore: switch Dependabot from pip to uv ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,8 @@ updates:
     commit-message:
       prefix: "deps"
 
-  # Python dependencies (uv/pip ecosystem)
-  - package-ecosystem: "pip"
+  # Python dependencies (uv ecosystem)
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## Summary

- Switch `package-ecosystem` from `pip` to `uv` in `dependabot.yml`
- nexus-mcp uses uv for package management (`uv sync`, `uv.lock`), so Dependabot should use the `uv` ecosystem for native lock file support
- Aligns with dep-rank which already uses `uv` ecosystem