### PR TITLE
fix: pin shared-workflows@v1.2.2 (PR author fix for re-runs)

### DIFF
--- a/.github/workflows/dependency-cooldown-gate.yml
+++ b/.github/workflows/dependency-cooldown-gate.yml
@@ -15,6 +15,6 @@ concurrency:
 
 jobs:
   gate:
-    uses: j7an/shared-workflows/.github/workflows/dependency-cooldown-gate.yml@a60e4d58bb9dcc3a6311477f46c6ef707708a13d # v1.2.1
+    uses: j7an/shared-workflows/.github/workflows/dependency-cooldown-gate.yml@6d471d8f4aa1b94140f352e38b308ff30fc61cee # v1.2.2
     with:
       cooling_business_days: 5

--- a/.github/workflows/dependency-cooldown-scan.yml
+++ b/.github/workflows/dependency-cooldown-scan.yml
@@ -16,6 +16,6 @@ concurrency:
 
 jobs:
   scan:
-    uses: j7an/shared-workflows/.github/workflows/dependency-cooldown-scan.yml@a60e4d58bb9dcc3a6311477f46c6ef707708a13d # v1.2.1
+    uses: j7an/shared-workflows/.github/workflows/dependency-cooldown-scan.yml@6d471d8f4aa1b94140f352e38b308ff30fc61cee # v1.2.2
     with:
       cooling_business_days: 5


### PR DESCRIPTION
## Summary

Update shared-workflows SHA pin from v1.2.1 to v1.2.2.

## What changed in v1.2.2

Replaces `github.actor` with `github.event.pull_request.user.login` for bot detection in the gate workflow. Fixes two bugs on workflow re-runs:

1. **Cooldown bypass** — re-running the gate on a Dependabot PR no longer incorrectly sets status to `success`
2. **Missing Fixes link** — tracking issue job no longer skipped on re-runs, so `Fixes #N` is added to PR body

Also resolves `zizmor/bot-conditions` warning.

## Test plan

- [ ] Merge this PR
- [ ] Re-run gate on Dependabot PRs #136-138
- [ ] Verify `Fixes #N` links appear in PR bodies
- [ ] Verify cooldown status remains `pending`