### PR TITLE
fix: pin shared-workflows@v1.2.3 (resilient Fixes link)

### DIFF
--- a/.github/workflows/dependency-cooldown-gate.yml
+++ b/.github/workflows/dependency-cooldown-gate.yml
@@ -15,6 +15,6 @@ concurrency:
 
 jobs:
   gate:
-    uses: j7an/shared-workflows/.github/workflows/dependency-cooldown-gate.yml@6d471d8f4aa1b94140f352e38b308ff30fc61cee # v1.2.2
+    uses: j7an/shared-workflows/.github/workflows/dependency-cooldown-gate.yml@978b3ebc19f12e9fcd39a2129ea9387483e500a3 # v1.2.3
     with:
       cooling_business_days: 5

--- a/.github/workflows/dependency-cooldown-scan.yml
+++ b/.github/workflows/dependency-cooldown-scan.yml
@@ -16,6 +16,6 @@ concurrency:
 
 jobs:
   scan:
-    uses: j7an/shared-workflows/.github/workflows/dependency-cooldown-scan.yml@6d471d8f4aa1b94140f352e38b308ff30fc61cee # v1.2.2
+    uses: j7an/shared-workflows/.github/workflows/dependency-cooldown-scan.yml@978b3ebc19f12e9fcd39a2129ea9387483e500a3 # v1.2.3
     with:
       cooling_business_days: 5


### PR DESCRIPTION
## Summary

Update shared-workflows SHA pin from v1.2.2 to v1.2.3.

## What changed in v1.2.3

Adds a new "Ensure Fixes link" step in the `set-pending-status` job that runs on both `opened` and `synchronize` events. If the `create-tracking-issue` job fails on first run, the next push to the PR recovers by adding the `Fixes #N` link automatically.

## Test plan

- [ ] New Dependabot PR gets Fixes link on open
- [ ] If tracking issue job fails, next push adds the Fixes link