### PR TITLE
chore: group Dependabot PRs, reduce scan to weekday mornings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    groups:
+      all-actions:
+        patterns: ["*"]
     commit-message:
       prefix: "deps"
 

--- a/.github/workflows/dependency-cooldown-scan.yml
+++ b/.github/workflows/dependency-cooldown-scan.yml
@@ -2,7 +2,7 @@ name: Dependency Cool-Down Scan
 
 on:
   schedule:
-    - cron: "0 */6 * * *"
+    - cron: "0 9 * * 1-5"  # Weekdays at 09:00 UTC, skip weekends
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

- Group all GitHub Actions updates into a single batched PR
- Reduce cooldown scan from every 6 hours to once daily at 9am UTC, weekdays only

## Changes

| Setting | Before | After |
|---------|--------|-------|
| Actions grouping | None (1 PR per action) | `all-actions` group (1 PR total) |
| Scan schedule | `0 */6 * * *` (4x daily, 7 days) | `0 9 * * 1-5` (1x daily, weekdays) |
| Estimated emails/day | ~16 (4 scans × 4 PRs) | ~1 (1 scan × fewer PRs) |

## Why

The 6-hour scan frequency generated excessive email notifications (every scan that updates a PR comment triggers a GitHub notification). Since the cooldown is 5 business days, daily weekday scans provide the same security coverage with far less noise.