### PR TITLE
chore: disable tracking issues, cleanup existing ones

### DIFF
--- a/.github/workflows/dependency-cooldown-gate.yml
+++ b/.github/workflows/dependency-cooldown-gate.yml
@@ -6,8 +6,6 @@ on:
 
 permissions:
   statuses: write
-  issues: write
-  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -18,3 +16,4 @@ jobs:
     uses: j7an/shared-workflows/.github/workflows/dependency-cooldown-gate.yml@978b3ebc19f12e9fcd39a2129ea9387483e500a3 # v1.2.3
     with:
       cooling_business_days: 5
+      create_tracking_issue: false


### PR DESCRIPTION
## Summary

- Set `create_tracking_issue: false` in gate workflow
- Remove `issues: write` permission (no longer needed)
- Closed 5 stale tracking issues (#139, #140, #141, #144, #151)
- Removed `Fixes #N` links from open Dependabot PR bodies

## Why

Tracking issues add no value for grouped Dependabot PRs — the PR body already contains package details, changelogs, and commit info. The cooldown scan comment on the PR provides security data. The tracking issue was a pale duplicate with worse data (wrong package names for grouped PRs).