### PR TITLE
fix(ci): bump shared-workflows to v1.3.1 to restore cool-down scan

### DIFF
--- a/.github/workflows/dependency-cooldown-gate.yml
+++ b/.github/workflows/dependency-cooldown-gate.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   gate:
-    uses: j7an/shared-workflows/.github/workflows/dependency-cooldown-gate.yml@978b3ebc19f12e9fcd39a2129ea9387483e500a3 # v1.2.3
+    uses: j7an/shared-workflows/.github/workflows/dependency-cooldown-gate.yml@b0a5ece145440e853e1a489acf797793fa1d55f8 # v1.3.1
     with:
       cooling_business_days: 5
       create_tracking_issue: false

--- a/.github/workflows/dependency-cooldown-scan.yml
+++ b/.github/workflows/dependency-cooldown-scan.yml
@@ -16,6 +16,6 @@ concurrency:
 
 jobs:
   scan:
-    uses: j7an/shared-workflows/.github/workflows/dependency-cooldown-scan.yml@978b3ebc19f12e9fcd39a2129ea9387483e500a3 # v1.2.3
+    uses: j7an/shared-workflows/.github/workflows/dependency-cooldown-scan.yml@b0a5ece145440e853e1a489acf797793fa1d55f8 # v1.3.1
     with:
       cooling_business_days: 5


### PR DESCRIPTION
## Summary

- Bumps `j7an/shared-workflows` pin from `v1.2.3` (`978b3ebc`) to `v1.3.1` (`22c6a8c0`) in both `dependency-cooldown-scan.yml` and `dependency-cooldown-gate.yml`.
- Restores the scheduled dependency cool-down scan, which has been failing every run since v1.2.3 landed.

## Why

The `v1.2.3` "Find mature bot PRs" step used a broken shell pattern:

```bash
PR_NUMBERS=$(echo "$PR_DATA" | python3 << 'PYEOF'
...
prs = json.load(sys.stdin)
...
PYEOF
)
```

The heredoc and the pipe both target Python's stdin. The heredoc wins as the script source, stdin is exhausted, and `json.load(sys.stdin)` crashes with `JSONDecodeError: Expecting value: line 1 column 1 (char 0)` on every cron run. Failed runs include: `24238052101`, `24185012607`, `24130145773`, `24076176590`, `24028056628` — every scheduled run since the pin, no PRs scanned.

`v1.3.0` (upstream) fixes the step to pass `PR_DATA` via env var and use `json.loads(os.environ["PR_DATA"])`. `v1.3.1` is the current tip — a release-machinery patch (App token for `release.yml` trigger) on top of the fix. The upstream diff touches both the scan and the gate workflow, so bumping both in lockstep.

## Input compatibility

Verified against `on.workflow_call.inputs` on the tagged files at `v1.3.1`:

| Caller input | Still accepted at v1.3.1? |
|---|---|
| `cooling_business_days: 5` | yes (scan + gate) |
| `create_tracking_issue: false` | yes (gate) |

No renames, no new required inputs — pin bump is drop-in.

## Test plan

- [ ] Merge and wait for next weekday 09:00 UTC cron firing, OR trigger via `gh workflow run dependency-cooldown-scan.yml`
- [ ] Confirm "Find mature bot PRs" step exits green (no `JSONDecodeError`)
- [ ] If any mature bot PRs are open, confirm a scan comment is posted with HTML marker `<!-- dependency-scan-<N> -->`
- [ ] Open a dummy dependabot-style PR and confirm the gate workflow posts the pending commit status