### PR TITLE
fix: auto-merge Dependabot PRs after clean cooldown scan

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+      time: "18:00"
+      timezone: "America/Los_Angeles"
     groups:
       all-actions:
         patterns: ["*"]
@@ -18,6 +20,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+      time: "18:00"
+      timezone: "America/Los_Angeles"
     groups:
       minor-and-patch:
         patterns: ["*"]

--- a/.github/workflows/dependency-cooldown-scan.yml
+++ b/.github/workflows/dependency-cooldown-scan.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   scan:
-    uses: j7an/shared-workflows/.github/workflows/dependency-cooldown-scan.yml@6c45df24a3c06375b9f9b49de609f277f10afe17 # v1.3.2
+    uses: j7an/shared-workflows/.github/workflows/dependency-cooldown-scan.yml@72e54204a9d6cd988e43b95e74d155cf797c0617 # v1.3.2
     with:
       cooling_business_days: 5
       auto_merge: true

--- a/.github/workflows/dependency-cooldown-scan.yml
+++ b/.github/workflows/dependency-cooldown-scan.yml
@@ -2,11 +2,11 @@ name: Dependency Cool-Down Scan
 
 on:
   schedule:
-    - cron: "0 9 * * 1-5"  # Weekdays at 09:00 UTC, skip weekends
+    - cron: "0 15 * * 1-5"  # 8am PT (PDT) / 7am PT (PST)
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write      # needed for gh pr merge (auto-merge)
   pull-requests: write
   statuses: write
 
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   scan:
-    uses: j7an/shared-workflows/.github/workflows/dependency-cooldown-scan.yml@b0a5ece145440e853e1a489acf797793fa1d55f8 # v1.3.1
+    uses: j7an/shared-workflows/.github/workflows/dependency-cooldown-scan.yml@6c45df24a3c06375b9f9b49de609f277f10afe17 # v1.3.2
     with:
       cooling_business_days: 5
+      auto_merge: true


### PR DESCRIPTION
## Summary

- Schedule Dependabot at 6pm PT Monday (avoids same-day race with cooldown scan)
- Move cooldown scan cron to 8am PT (15:00 UTC) for 10-hour buffer
- Enable `auto_merge: true` in cooldown scan workflow (shared-workflows v1.3.2)
- Add `contents: write` permission for `gh pr merge`

Fixes the Sisyphean cycle where Dependabot closes scan-commented PRs before manual review, restarting the 5-day cooldown each week.

## Schedule

```
 8:00am PT   Cooldown scan fires, finds eligible PR, scans, auto-merges if clean
    ...      ~10 hour buffer
 6:00pm PT   Dependabot checks — old PR already merged
```

## Test plan

- [ ] Trigger `workflow_dispatch` to verify scan runs at new cron time
- [ ] Verify next Dependabot PR opens at ~6pm PT Monday
- [ ] Monitor first full Monday cycle: scan at 8am → auto-merge → Dependabot at 6pm
- [ ] Verify PR with advisories gets `security-review-needed` label and is NOT auto-merged