### PR TITLE
fix(ci): bump shared-workflows to v2.0.1 for version-aware advisory filtering

### DIFF
--- a/.github/workflows/dependency-cooldown.yml
+++ b/.github/workflows/dependency-cooldown.yml
@@ -16,6 +16,6 @@ concurrency:
 
 jobs:
   cooldown:
-    uses: j7an/shared-workflows/.github/workflows/dependency-cooldown.yml@24fa8536adba8846cb60fe2d6b6f0906c5bc8d7e # v2.0.0
+    uses: j7an/shared-workflows/.github/workflows/dependency-cooldown.yml@f8d50abc2805425906ef567df64d4ffabff4341f # v2.0.1
     with:
       auto_merge: true


### PR DESCRIPTION
## Summary

- Bumps `j7an/shared-workflows` from **v2.0.0** (`24fa8536...`) to **v2.0.1** (`f8d50abc2805425906ef567df64d4ffabff4341f`) in `.github/workflows/dependency-cooldown.yml`.
- v2.0.1 fixes a false-positive bug in the dependency scanner: v2.0.0 queried GHSA and OSV without filtering by the target version, so it reported every historical advisory for a package regardless of whether it was already patched.
- Observed symptom: PR #160 surfaced 10 advisories for `step-security/harden-runner` (5 unique × 2 sources), all patched in v2.16.0 or earlier. None actually affect v2.16.1.

## Upstream references

- Issue: j7an/shared-workflows#21
- Fix PR: j7an/shared-workflows#23

## Test plan

- [ ] CI green on this PR (gate auto-passes for human-authored PRs)
- [ ] After merge: comment `@dependabot rebase` on #160
- [ ] After rebase: confirm the 5 harden-runner GHSA IDs (`46g3-37rh-v698`, `g699-3x6g-wm3g`, `cpmj-h4f6-r6pq`, `mxr3-8whj-j74r`, `g85v-wf27-67xc`) move out of the active advisories table
- [ ] Auto-merge proceeds on #160 unless a *genuine* unpatched advisory is newly surfaced