### PR TITLE
fix(ci): bump shared-workflows to v2.0.3 for cooldown regression fixes

### DIFF
--- a/.github/workflows/dependency-cooldown.yml
+++ b/.github/workflows/dependency-cooldown.yml
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   cooldown:
-    uses: j7an/shared-workflows/.github/workflows/dependency-cooldown.yml@f8d50abc2805425906ef567df64d4ffabff4341f # v2.0.1
+    uses: j7an/shared-workflows/.github/workflows/dependency-cooldown.yml@16b94fd3461af6e9fe6e6174d805c7879fb39bb4 # v2.0.2
     with:
       auto_merge: true
+      cooldown_days: 7

--- a/.github/workflows/dependency-cooldown.yml
+++ b/.github/workflows/dependency-cooldown.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   cooldown:
-    uses: j7an/shared-workflows/.github/workflows/dependency-cooldown.yml@16b94fd3461af6e9fe6e6174d805c7879fb39bb4 # v2.0.2
+    uses: j7an/shared-workflows/.github/workflows/dependency-cooldown.yml@63d902124965191252737b399960e46f2f63e26a # v2.0.3
     with:
       auto_merge: true
       cooldown_days: 7


### PR DESCRIPTION
## Summary

Bumps `.github/workflows/dependency-cooldown.yml` from shared-workflows v2.0.1 → v2.0.3 and sets `cooldown_days: 7` explicitly. Closes a four-regression cascade in shared-workflows that was actively affecting this repo's CI.

## The regression cascade

This PR went through an unusually visible upstream stabilization window. The v2 line of shared-workflows was published over a ~36-hour stretch during which we (this repo) reported four distinct regressions and watched them get fixed in real time:

| Issue | What broke | Fixed in |
|---|---|---|
| [j7an/shared-workflows#25](https://github.com/j7an/shared-workflows/issues/25) | `@dependabot rebase` silently bypassed the cooldown — the workflow enabled auto-merge on releases that were inside the 7-day cooldown window | shared-workflows#28 → v2.0.2 |
| [j7an/shared-workflows#26](https://github.com/j7an/shared-workflows/issues/26) | `security-review-needed` label stuck through merge after a dirty-then-clean re-scan, polluting merged-PR state | shared-workflows#28 → v2.0.2 |
| [j7an/shared-workflows#27](https://github.com/j7an/shared-workflows/issues/27) | `astral-sh/setup-uv` (and any `- uses:` list-marker action) was silently dropped from the diff extractor | shared-workflows#28 → v2.0.2 |
| [j7an/shared-workflows#29](https://github.com/j7an/shared-workflows/issues/29) | v2.0.2's new `actions/checkout` step used `github.workflow_sha`, which resolves to the **caller's** PR merge ref (not the reusable workflow's commit) — every consumer PR failed deterministically at the checkout step | shared-workflows#31 → v2.0.3 |

All four were originally surfaced by this repo's own PRs ([nexus-mcp#160](https://github.com/j7an/nexus-mcp/pull/160) for #25/#26/#27, and the first revision of this PR for #29). nexus-mcp#160's diff is now captured as the permanent bats regression fixture in shared-workflows (`tests/fixtures/extract-deps/nexus-mcp-160.diff`).

## What this PR does

- Pin: `j7an/shared-workflows/.github/workflows/dependency-cooldown.yml@63d902124965191252737b399960e46f2f63e26a # v2.0.3` (was v2.0.1).
- Adds `cooldown_days: 7` to the `with:` block, mirroring `.github/dependabot.yml`'s `cooldown.default-days: 7`. Functionally redundant against v2.0.3's default but pinned for symmetry and to defend against any future upstream default change.

The branch contains two commits, intentionally not squashed locally:
1. `21583b1` — bump v2.0.1 → v2.0.2 (broken by [#29](https://github.com/j7an/shared-workflows/issues/29))
2. `9c06b89` — bump v2.0.2 → v2.0.3 (resolves [#29](https://github.com/j7an/shared-workflows/issues/29))

The two-commit shape preserves the honest "we tried v2.0.2, it had a regression, v2.0.3 fixed it" narrative for any future reader running `git log` on this branch. Net diff against main is identical to a hypothetical direct v2.0.1 → v2.0.3 bump (1 deletion / 2 insertions).

## Verification

Pre-merge (local, both bumps):

- [x] YAML parse check on both commits
- [x] Diff accounting on both commits (final net: 1 file, 2 insertions, 1 deletion)
- [x] v2.0.3 → `63d902124965191252737b399960e46f2f63e26a` verified via two independent `gh api` paths (commits endpoint + tag-object dereference)
- [x] v2.0.3 input surface confirmed identical to v2.0.2 (`enable_scorecard`, `auto_merge`, `cooldown_days`, `fail_on_cooldown`)
- [x] v2.0.3 source inspected for #29 fix: `Checkout shared-workflows scripts` step removed (Option A — scripts re-inlined), `Set initial status` reordered to be the first step after `Harden runner`, comment block at lines 26–32 references #29 explicitly

CI on this PR's HEAD (commit `9c06b89`):

- [x] `cooldown / scan` job — SUCCESS (#29 regression confirmed fixed in our consumer context)
- [x] `dependency-cooldown / gate` commit status — SUCCESS
- [x] CI test matrix — 6/6 passing (Python 3.13/3.14 × ubuntu/macos/windows)
- [x] `lint`, `typecheck`, `CodeQL`, `zizmor`, `Zizmor`, `TruffleHog` — all green
- [ ] Next Dependabot run (next Monday 18:00 PT): scan comment lists *all* actions in the diff, "Release Age" section present, gate ends at `success`, auto-merge fires on a clean aged bundle
- [ ] If a rebase ever pulls in a sub-7-day release: `cooldown-pending` label applied, gate ends at `pending` (not `failure` — soft-gate choice), auto-merge withheld until release ages out
- [ ] If a dirty-then-clean re-scan ever occurs: `security-review-needed` removed on the clean run

## Note on the failing `Trivy` (Security Scanning) check

The `Trivy` check inside the `Security Scanning` workflow is red on this PR, but it is **pre-existing on `main`** — it has been failing since at least 2026-04-12 on `lupa==2.6` / CVE-2026-34444 (HIGH, no fixed version yet). PRs #156, #158, and #161 all merged with this exact check red. It is not introduced by this PR's diff (which doesn't touch `uv.lock`) and should be addressed in its own follow-up PR.