### PR TITLE
feat(ci): add cooldown-rescan caller workflow (dry-run phase)

### DIFF
--- a/.github/workflows/dependency-cooldown-rescan.yml
+++ b/.github/workflows/dependency-cooldown-rescan.yml
@@ -1,0 +1,18 @@
+name: Dependency Cool-Down Rescan
+
+on:
+  schedule:
+    - cron: "17 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+  actions: write
+  statuses: read
+
+jobs:
+  rescan:
+    uses: j7an/shared-workflows/.github/workflows/cooldown-rescan.yml@68158ca145a6a90a0d2b890b23c7103513f442ce # v2.4.0
+    with:
+      dry_run: true


### PR DESCRIPTION
## Summary

Adds `.github/workflows/dependency-cooldown-rescan.yml`, a scheduled caller for the upstream `j7an/shared-workflows` v2.4.0 `cooldown-rescan.yml` reusable workflow. This is **phase 1 of 2** — ships with `dry_run: true` so the sweep logs decisions to the run summary without actually re-running any cooldown workflows. A follow-up PR will remove the input to go live.

## Why

PR #163 surfaced the gap: the existing `dependency-cooldown.yml` only fires on `pull_request` events, so Dependabot PRs opened during a dependency's cooldown window sit stuck until a human comments `@dependabot recreate`. See https://github.com/j7an/nexus-mcp/pull/163#issuecomment-4240606855.

## What changes

- Daily cron at 06:17 UTC + \`workflow_dispatch\` manual trigger.
- Calls upstream \`cooldown-rescan.yml@68158ca...\` pinned to \`v2.4.0\`.
- \`dry_run: true\` — this PR has **zero side effects** on any existing PR.

## Test plan

- [ ] CI passes on this PR.
- [ ] After merge, trigger via \`gh workflow run dependency-cooldown-rescan.yml\` and inspect the run summary.
- [ ] Confirm the summary table lists any open Dependabot PRs currently gated \`pending\`, with \`Action: DRY-RUN: would rerun run <id>\`.
- [ ] Confirm the sweep does NOT actually call \`gh run rerun\` (no new runs appear on target PRs).
- [ ] Follow-up PR will remove \`dry_run: true\`.

## Spec

See \`docs/superpowers/specs/2026-04-17-cooldown-rescan-design.md\` (local; not committed per preference).