### PR TITLE
feat(ci): make cooldown-rescan dry_run UI-toggleable

### DIFF
--- a/.github/workflows/dependency-cooldown-rescan.yml
+++ b/.github/workflows/dependency-cooldown-rescan.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: "17 6 * * *"
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "If true, log decisions but skip gh run rerun"
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -15,4 +20,4 @@ jobs:
   rescan:
     uses: j7an/shared-workflows/.github/workflows/cooldown-rescan.yml@68158ca145a6a90a0d2b890b23c7103513f442ce # v2.4.0
     with:
-      dry_run: true
+      dry_run: ${{ inputs.dry_run || false }}


### PR DESCRIPTION
## Summary

Phase 2 of 2 for the cooldown-rescan feature. Makes `dry_run` toggleable from the GitHub Actions UI instead of hardcoded. Scheduled runs default to `dry_run: false` (live) — so the nightly cron actually reruns qualifying cooldown workflows. Manual `workflow_dispatch` runs expose a checkbox defaulting to unchecked (live), with an opt-in for dry-run diagnostics without editing YAML.

## Pre-conditions (all verified in Phase 1)

- Upstream `v2.4.0` reusable workflow exists and is pinned by commit SHA.
- Dry-run sweep correctly identifies qualifying PRs.
- Dry-run sweep does NOT call `gh run rerun` (verified via harden-runner egress audit — only three outbound `gh` calls per sweep: list PRs, fetch status, list prior runs).

## What changes

Two additions, one modification in the caller workflow:

1. Adds an `inputs:` block under `workflow_dispatch:` declaring a boolean `dry_run` with `default: false` and a human-readable description.
2. Changes `with: dry_run: true` to `with: dry_run: \${{ inputs.dry_run || false }}` so the value threads through from the UI input, with `false` fallback for scheduled runs where the `inputs` context is empty.

## Test plan

- [ ] CI passes.
- [ ] After merge, dispatch once via UI with `dry_run` **unchecked** (live). Confirm summary shows `Action: rerun run <id>` (no "DRY-RUN:" prefix) for qualifying PRs.
- [ ] Confirm each reran PR gets a fresh `Dependency Cool-Down` run, updated scan comment, and (if cooldown has expired) gate goes green + auto-merge engages.
- [ ] Dispatch once more with `dry_run` **checked**. Confirm summary reverts to `would-rerun-<id>` rows and no new cooldown runs are triggered — validates input plumbing in both directions.

## Spec

See `docs/superpowers/specs/2026-04-17-cooldown-rescan-design.md` §Open Questions #1 (local; not committed per preference). This PR realizes the "keep dry_run as a permanent input" decision recorded there on 2026-04-18.