### PR TITLE
feat(release): adopt dynamic versioning via hatch-vcs and fix release.yml latent bugs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,9 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Verify tag is on main
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,12 +149,23 @@ jobs:
           name: dist
           path: dist/
 
+      - name: Classify tag (stable vs prerelease)
+        id: classify
+        env:
+          REF: ${{ github.ref_name }}
+        run: |
+          if [[ "$REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(\.post[0-9]+)?$ ]]; then
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create GitHub Release with assets
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           generate_release_notes: true
           draft: true
-          prerelease: ${{ contains(github.ref_name, '-') }}
+          prerelease: ${{ steps.classify.outputs.prerelease }}
           files: dist/*
 
   publish-mcp-registry:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nexus-mcp"
-version = "0.10.0"
+dynamic = ["version"]
 description = "Model Context Protocol server for AI CLI agents"
 readme = "README.md"
 authors = [
@@ -52,9 +52,13 @@ Issues = "https://github.com/j7an/nexus-mcp/issues"
 nexus-mcp = "nexus_mcp.__main__:main"
 
 [build-system]
-requires = ["hatchling>=1.28.0"]
+requires = ["hatchling>=1.28.0", "hatch-vcs>=0.4.0"]
 build-backend = "hatchling.build"
 # Note: hatchling>=1.28.0 auto-discovers src-layout; no [tool.hatch.build.targets.wheel] needed
+
+[tool.hatch.version]
+source = "vcs"
+raw-options = { version_scheme = "no-guess-dev" }
 
 [dependency-groups]
 dev = [

--- a/server.json
+++ b/server.json
@@ -1,8 +1,9 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "_comment": "version fields are publish-time placeholders — see release.yml publish-mcp-registry jq patch",
   "name": "io.github.j7an/nexus-mcp",
   "description": "Invoke CLI agents (Gemini, Codex, Claude, OpenCode) as MCP tools with parallel execution",
-  "version": "0.8.1",
+  "version": "0.0.0",
   "repository": {
     "url": "https://github.com/j7an/nexus-mcp",
     "source": "github"
@@ -11,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "nexus-mcp",
-      "version": "0.8.1",
+      "version": "0.0.0",
       "runtimeHint": "uvx",
       "runtimeArguments": [
         { "type": "positional", "value": "--python", "isRequired": true },

--- a/uv.lock
+++ b/uv.lock
@@ -947,7 +947,6 @@ wheels = [
 
 [[package]]
 name = "nexus-mcp"
-version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp", extra = ["tasks"] },


### PR DESCRIPTION
## Summary
- Migrate `pyproject.toml` from static `version = "0.10.0"` to dynamic versioning via `hatch-vcs`. The git tag becomes the single source of truth for the Python package version — no more hand-edited version strings.
- Fix latent bug in `release.yml` build-job checkout: add `fetch-depth: 0` + `fetch-tags: true`. Required now that hatch-vcs reads the version from tags at build time. Scoped narrowly — other jobs' checkouts unchanged.
- Replace `release.yml`'s hyphen-based prerelease detection with an anchored-regex classifier step. The previous test (`contains(github.ref_name, '-')`) fails under PEP 440 canonical tags like `v1.2.3rc1`. The new classifier is fail-safe — unknown tag shapes default to `prerelease=true`.
- Make `server.json` version fields explicit publish-time placeholders (`"0.0.0"` with a `_comment` field). The `.version` and `.packages[0].version` fields have always been overwritten at publish time by the `jq` patch in `publish-mcp-registry` — this commit documents the design rather than hand-syncing to a "current" value that would drift again next release.

## Why
Prerequisite for upcoming PR #2, which will add a UI-driven `Tag Release` caller workflow that delegates to `j7an/shared-workflows/.github/workflows/tag-release.yml` for Conventional-Commits-driven auto-bumping. Without dynamic versioning, auto-bump would require hand-editing `pyproject.toml` before every tag — defeating the point of the automation.

## Test plan
- [x] `uv run pytest` green on the branch (1248 passed, 11 skipped — matches baseline)
- [x] `uv run mypy src/nexus_mcp` clean
- [x] `uv run ruff check .` + `ruff format --check .` clean
- [x] `uv run pre-commit run --all-files` passes
- [x] Local `uv build` on the feature branch (HEAD past v0.10.0) produces a PEP 440 post-release-dev version (expected hatch-vcs behavior off-tag); on a real tag checkout, will produce a clean version string matching the tag
- [x] Classifier regex dry-run: `v1.2.3` / `v1.2.3.post1` → stable; `v1.2.3rc1` / `v1.2.3a1` / `v1.2.3b1` / `v1.2.3.dev1` / `v1.2.3+build.1` / `v1.2.3-rc1` → prerelease
- [x] `jq` publish-time patch dry-run on the new `server.json` correctly rewrites both version fields
- [ ] CI green on this PR
- [ ] Post-merge: ship a real release (next patch) to verify the sourcing works end-to-end before PR #2 lands

## Follow-up
PR #2 — new `.github/workflows/tag-release.yml` caller that delegates to `j7an/shared-workflows`'s reusable `tag-release.yml@v2.4.0` for UI-driven auto-bump. Depends on this PR landing and on one-time Release Bot App wiring (install App on repo, set `vars.RELEASE_BOT_APP_ID`, create `release` environment with `RELEASE_BOT_PRIVATE_KEY` secret).

## Security note
The new classifier step uses `env: REF: \${{ github.ref_name }}` and references `\$REF` inside the bash regex — the recommended pattern for untrusted workflow inputs. No direct `\${{ }}` interpolation inside any `run:` block.