### PR TITLE
docs: label OpenCode Server as experimental

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,9 @@ uv run python -m nexus_mcp
 </details>
 
 <details>
-<summary><h3>OpenCode Server (Docker)</h3></summary>
+<summary><h3>OpenCode Server (Docker) — experimental</h3></summary>
+
+> ⚠️ **Experimental** — This integration has not been validated end-to-end by the maintainer. Expect rough edges in setup, auth, and tool exposure. The MCP tools surfaced from upstream OpenCode track the upstream project and may change without notice. Feedback and bug reports are welcome.
 
 Run an isolated [OpenCode](https://opencode.ai) server for HTTP-based agent execution alongside the CLI runner. Provides session management, file search, permissions, and 38 additional MCP tools when the server is healthy.
 

--- a/docs/opencode-server-setup.md
+++ b/docs/opencode-server-setup.md
@@ -1,6 +1,8 @@
-# OpenCode Server Setup Guide
+# OpenCode Server Setup Guide — experimental
 
 Run an isolated OpenCode server via Docker for HTTP-based agent execution. This enables session management, file search, workspace tools, permissions, and questions — capabilities not available through the CLI subprocess runner.
+
+> ⚠️ **Experimental** — This integration has not been validated end-to-end by the maintainer. Expect rough edges in setup, auth, and tool exposure. The MCP tools surfaced from upstream OpenCode track the upstream project and may change without notice. Feedback and bug reports are welcome.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary

- Adds `— experimental` suffix to the OpenCode Server (Docker) section heading in `README.md` (line 198) and the H1 of `docs/opencode-server-setup.md`.
- Inserts an identical blockquote callout at the top of each section naming why: the integration has not been validated end-to-end by the maintainer, and the MCP tools surfaced from upstream OpenCode track the upstream project without a version pin.
- Docs-only. No code, test, or MCP schema changes. Commit prefix is `docs:` so release-please will not bump the version.

## Rationale

The OpenCode Server section currently reads as a first-class supported capability. Readers landing on either surface (README or the standalone setup guide) have no stability signal. A consistent, specific callout in both places calibrates expectations without removing functionality.

Identical wording in both files means a future removal (once validated) is a single find-and-replace.

## What changed

| File | Edit |
|------|------|
| `README.md` | Heading suffix + blockquote callout inside the `<details>` block |
| `docs/opencode-server-setup.md` | H1 suffix + blockquote callout between intro and Prerequisites |

## Test plan

- [x] `uv run pytest -q --no-cov --ignore=tests/integration` — 1237 passed (unchanged baseline)
- [x] `uv run pre-commit run --all-files` — all 11 hooks pass
- [x] `git diff --check` clean (no trailing whitespace introduced)
- [x] Byte-identical callout verified in both files via grep
- [ ] Visual render check on GitHub: `<details>` still collapses/expands, em-dash renders as `—`, warning emoji visible, blockquote renders as blockquote