### PR TITLE
feat(ci): adopt shared-workflows v2.5.1 and enable server.json auto-bump

### DIFF
--- a/.github/workflows/dependency-cooldown-rescan.yml
+++ b/.github/workflows/dependency-cooldown-rescan.yml
@@ -18,6 +18,6 @@ permissions:
 
 jobs:
   rescan:
-    uses: j7an/shared-workflows/.github/workflows/cooldown-rescan.yml@68158ca145a6a90a0d2b890b23c7103513f442ce # v2.4.0
+    uses: j7an/shared-workflows/.github/workflows/cooldown-rescan.yml@c092d60b64e29d03b67d49e8a8471bdfd61cee5a # v2.5.1
     with:
       dry_run: ${{ inputs.dry_run || false }}

--- a/.github/workflows/dependency-cooldown.yml
+++ b/.github/workflows/dependency-cooldown.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   cooldown:
-    uses: j7an/shared-workflows/.github/workflows/dependency-cooldown.yml@63d902124965191252737b399960e46f2f63e26a # v2.0.3
+    uses: j7an/shared-workflows/.github/workflows/dependency-cooldown.yml@c092d60b64e29d03b67d49e8a8471bdfd61cee5a # v2.5.1
     with:
       auto_merge: true
       cooldown_days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,12 +182,6 @@ jobs:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Patch server.json version from tag
-        run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          jq --arg v "$VERSION" '.version = $v | .packages[0].version = $v' server.json > server.tmp.json
-          mv server.tmp.json server.json
-
       - name: Install mcp-publisher
         run: |
           curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   tag:
-    uses: j7an/shared-workflows/.github/workflows/tag-release.yml@68158ca145a6a90a0d2b890b23c7103513f442ce # v2.4.0
+    uses: j7an/shared-workflows/.github/workflows/tag-release.yml@c092d60b64e29d03b67d49e8a8471bdfd61cee5a # v2.5.1
     with:
       bump: ${{ inputs.bump }}
       tag-prefix: "v"

--- a/.version-bump.json
+++ b/.version-bump.json
@@ -1,0 +1,6 @@
+{
+  "files": [
+    { "path": "server.json", "path_expr": ".version" },
+    { "path": "server.json", "path_expr": ".packages[0].version" }
+  ]
+}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -32,8 +32,9 @@ These are already configured. Verify once if something seems broken:
      `<type>!:` or `BREAKING CHANGE:` → major)
    - `patch` / `minor` / `major` — override the auto analysis
 3. Click **Run workflow**. The shared `tag-release.yml` reusable workflow
-   computes the next version, pushes a signed `vX.Y.Z` tag via the Release
-   Bot App, and finishes
+   computes the next version, applies `.version-bump.json` to update
+   `server.json`'s two version fields, commits those changes, pushes a signed
+   `vX.Y.Z` tag via the Release Bot App, and finishes
 4. The `v*` tag push triggers `release.yml` (build → TestPyPI → PyPI →
    GitHub Release → MCP Registry) — same as a manual tag push
 
@@ -70,7 +71,7 @@ The `release.yml` workflow runs five jobs in sequence:
 | `publish-testpypi` | Publishes to TestPyPI, waits 30 s, installs and smoke-tests the package |
 | `publish-pypi` | **Waits for a required reviewer to approve** the `pypi` environment, then publishes |
 | `github-release` | Creates a **draft** GitHub Release with auto-generated notes; a regex classifier marks it as `prerelease: true` unless the tag matches `^v[0-9]+\.[0-9]+\.[0-9]+(\.post[0-9]+)?$` |
-| `publish-mcp-registry` | Patches `server.json` version from tag, authenticates via OIDC, publishes metadata to MCP Registry |
+| `publish-mcp-registry` | Authenticates via OIDC, publishes the committed `server.json` to MCP Registry |
 
 Monitor progress at:
 `https://github.com/j7an/nexus-mcp/actions`
@@ -84,26 +85,6 @@ Monitor progress at:
 - [ ] Smoke-test: `python -c "import nexus_mcp; print(nexus_mcp.__version__)"`
 - [ ] Open the draft GitHub Release, review auto-generated notes, and click **Publish release**
 - [ ] Verify the MCP Registry listing
-
----
-
-## About `server.json` version fields
-
-`server.json` holds MCP Registry metadata. The two version fields —
-`.version` and `.packages[0].version` — are **publish-time placeholders**,
-not authoritative values. The committed file stays at `"0.0.0"`; the
-`publish-mcp-registry` job in `release.yml` rewrites both fields from the
-tag name (`GITHUB_REF_NAME`) via a `jq` patch before calling
-`mcp-publisher publish`. The MCP Registry schema requires these fields to
-exist, but their values only become meaningful at publish time.
-
-The other ~12 fields in `server.json` (`$schema`, `name`, `description`,
-`repository.*`, `packages[0].identifier/runtimeHint/runtimeArguments/transport`)
-are authoritative source of truth — review them in PRs normally.
-
-Do not hand-edit the version fields to "match" the latest tag. A mismatch
-between `pyproject.toml`'s dynamic version and the committed `server.json`
-version is the designed steady state, not drift.
 
 ---
 

--- a/server.json
+++ b/server.json
@@ -1,9 +1,8 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "_comment": "version fields are publish-time placeholders — see release.yml publish-mcp-registry jq patch",
   "name": "io.github.j7an/nexus-mcp",
   "description": "Invoke CLI agents (Gemini, Codex, Claude, OpenCode) as MCP tools with parallel execution",
-  "version": "0.0.0",
+  "version": "0.10.0",
   "repository": {
     "url": "https://github.com/j7an/nexus-mcp",
     "source": "github"
@@ -12,7 +11,7 @@
     {
       "registryType": "pypi",
       "identifier": "nexus-mcp",
-      "version": "0.0.0",
+      "version": "0.10.0",
       "runtimeHint": "uvx",
       "runtimeArguments": [
         { "type": "positional", "value": "--python", "isRequired": true },


### PR DESCRIPTION
## Summary

Adopts `j7an/shared-workflows@v2.5.1` (`c092d60b64e29d03b67d49e8a8471bdfd61cee5a`) across all three caller workflows in this repo. With v2.5.1's [PR #47](https://github.com/j7an/shared-workflows/pull/47) landing nested `path_expr` support in `.version-bump.json`, this also closes the follow-up deferred by the 2026-04-19 auto-bump release design's "Future work" bullet: `server.json`'s two version fields are now auto-bumped at tag time, eliminating the runtime `jq` patch.

Also picks up [PR #51](https://github.com/j7an/shared-workflows/pull/51) — `extract-deps` now accepts large valid `uv.lock` diffs.

## Changes

- Unifies three shared-workflows pins at v2.5.1:
  - `.github/workflows/tag-release.yml`: v2.4.0 → v2.5.1
  - `.github/workflows/dependency-cooldown.yml`: v2.0.3 → v2.5.1
  - `.github/workflows/dependency-cooldown-rescan.yml`: v2.4.0 → v2.5.1
- Adds `.version-bump.json` targeting `server.json`'s `.version` and `.packages[0].version` via `path_expr` entries.
- Deletes the runtime `jq` patch in `release.yml`'s `publish-mcp-registry` job (now redundant).
- Removes the `_comment` field in `server.json` and the `RELEASE.md` "About `server.json` version fields" section.
- Commits `server.json` version fields at `0.10.0` (matching the current release).

Net: **+15 / −35 lines** (−20 net). A pure simplification.

## Test plan

Pre-merge (completed locally before push):
- [x] All four modified YAML files parse
- [x] `.version-bump.json` and `server.json` parse as JSON
- [x] `ruff check`, `ruff format --check`, `mypy` all pass
- [x] `pre-commit run` on the seven touched files passes
- [x] `uv run pytest` (1248 passed, 11 skipped) passes
- [x] Upstream SHA cross-check: `gh api repos/j7an/shared-workflows/commits/v2.5.1` returns the pinned SHA

Post-merge (to observe after this PR lands):
- [ ] Next Dependabot Monday run (2026-04-27): `all-actions` group PR either has nothing to propose or bumps any newer shared-workflows release uniformly across all three files.
- [ ] First `Tag Release` dispatch: verify a `chore(release): bump version files to <vX.Y.Z>` commit appears in `git log` around the new tag; verify the released wheel's METADATA Version matches the tag; verify the MCP Registry listing shows the correct version.
- [ ] `release.yml` run: no "Patch server.json" step appears in `publish-mcp-registry` job.

## Follow-ups

- [PR #48](https://github.com/j7an/shared-workflows/pull/48) (bracket-quoted keys + `[]` iterator) ships in v2.5.0+ but is not used here. Reserved for a hypothetical future multi-package `server.json`.