### PR TITLE
fix(ci): bump shared-workflows to v2.5.2 to close lockfile parser bug

### DIFF
--- a/.github/workflows/dependency-cooldown-rescan.yml
+++ b/.github/workflows/dependency-cooldown-rescan.yml
@@ -18,6 +18,6 @@ permissions:
 
 jobs:
   rescan:
-    uses: j7an/shared-workflows/.github/workflows/cooldown-rescan.yml@c092d60b64e29d03b67d49e8a8471bdfd61cee5a # v2.5.1
+    uses: j7an/shared-workflows/.github/workflows/cooldown-rescan.yml@365119edbe2b1c7339d7727d9e8d021784e5bc01 # v2.5.2
     with:
       dry_run: ${{ inputs.dry_run || false }}

--- a/.github/workflows/dependency-cooldown.yml
+++ b/.github/workflows/dependency-cooldown.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   cooldown:
-    uses: j7an/shared-workflows/.github/workflows/dependency-cooldown.yml@c092d60b64e29d03b67d49e8a8471bdfd61cee5a # v2.5.1
+    uses: j7an/shared-workflows/.github/workflows/dependency-cooldown.yml@365119edbe2b1c7339d7727d9e8d021784e5bc01 # v2.5.2
     with:
       auto_merge: true
       cooldown_days: 7

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   tag:
-    uses: j7an/shared-workflows/.github/workflows/tag-release.yml@c092d60b64e29d03b67d49e8a8471bdfd61cee5a # v2.5.1
+    uses: j7an/shared-workflows/.github/workflows/tag-release.yml@365119edbe2b1c7339d7727d9e8d021784e5bc01 # v2.5.2
     with:
       bump: ${{ inputs.bump }}
       tag-prefix: "v"


### PR DESCRIPTION
## Summary

- Bumps `j7an/shared-workflows` from v2.5.1 (`c092d60b…`) to v2.5.2 (`0ad4a1f4…`) across all three caller workflows.
- Closes a silent security-downgrade bug where the dependency-cooldown scanner returned `DEPS_TSV=""` for TOML lockfiles (`uv.lock`, `poetry.lock`, `Cargo.lock`), enabling auto-merge with the comment "No known exploits found" when zero versions had been scanned.
- Fix is three layered changes upstream: section-aware TOML parser, PR-body fallback primitive, and a fail-loud guard that refuses green gates when a lockfile is touched but no rows are extracted.

## Why this repo specifically

This exact bug was observed on nexus-mcp#170 (Dependabot uv.lock bump of pydantic, mypy, pytest, respx, ruff). Its cooldown comment rendered `Packages scanned: (no dependencies extracted from diff)` and still enabled auto-merge. #170 is the named reproducer in upstream issue #52 and acceptance criterion for upstream PR #53.

## Change surface

| File | Line | Before | After |
|---|---|---|---|
| `.github/workflows/dependency-cooldown.yml` | 19 | `@c092d60b… # v2.5.1` | `@0ad4a1f4… # v2.5.2` |
| `.github/workflows/dependency-cooldown-rescan.yml` | 21 | `@c092d60b… # v2.5.1` | `@0ad4a1f4… # v2.5.2` |
| `.github/workflows/tag-release.yml` | 22 | `@c092d60b… # v2.5.1` | `@0ad4a1f4… # v2.5.2` |

## Post-merge verification

Replay a parser-equivalent inverse of PR #170's lockfile diff on a synthetic verification PR, with PR #170's Dependabot body copied verbatim, to confirm the fix works against this repo's real input shape. Close the synthetic PR without merging after verification.

- [ ] Open synthetic PR as draft with #170's Dependabot body verbatim (full command in Task 9 Step 5 — uses `--body-file`, not `--body`)
- [ ] Wait for `Dependency Cool-Down` check to complete on the synthetic PR
- [ ] Assert the cooldown comment includes **Packages scanned:** listing pydantic, mypy, pytest, respx, ruff by name + version
- [ ] Assert the comment includes a populated **Release Age** section
- [ ] Assert the comment includes a populated **OpenSSF Scorecard / Project Health** section
- [ ] Assert the comment does NOT contain the string `(no dependencies extracted from diff)`
- [ ] `gh pr close <synthetic-pr-number> && git push origin --delete verify/v2.5.2-cooldown-replay`

Rescan caller smoke test:
- [ ] `gh workflow run dependency-cooldown-rescan.yml --ref main -f dry_run=true`
- [ ] Watch the dispatched run to completion (see plan Task 9 Step 9 for the full timestamp-fenced capture command; `--event workflow_dispatch` filter prevents picking up a concurrent scheduled run)
- [ ] Assert the run conclusion is `success` (rescan caller's YAML loads under v2.5.2 and the workflow_call interface matches).

Not smoke-tested post-merge: `tag-release.yml`. Running it cuts a real release. Its validation is its next organic invocation.

## Risk

Patch-level upstream bump. No input/output surface changes. Fail-loud guard is strictly safer than the current silent-success path.