### PR TITLE
fix(ci): grant contents:write so tag-release can push tags

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -15,7 +15,7 @@ on:
           - major
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   tag:


### PR DESCRIPTION
## Summary

- The `tag-release.yml` caller workflow declared `permissions: { contents: read }`, but the shared workflow (`j7an/shared-workflows/tag-release.yml`) requires `contents: write` to push the version-bump commit and annotated tag.
- GitHub enforces the caller's permissions as a ceiling for reusable workflows — the shared workflow's own `contents: write` declaration is what it *needs*, but the caller's `read` is what it *gets*. This caused workflow validation to reject the call before any job ran.
- Fix: `contents: read` → `contents: write` in the caller.

## Test plan

- [ ] Trigger Tag Release workflow via Actions UI (bump: auto) and confirm it no longer fails at validation
- [ ] Verify the computed tag and step summary appear correctly