### PR TITLE
fix(ci): canonicalize trivy-action version comments to satisfy zizmor

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -98,7 +98,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Generate SARIF report
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: repo
           format: sarif
@@ -112,7 +112,7 @@ jobs:
           category: trivy
 
       - name: Fail on CRITICAL/HIGH vulnerabilities
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: repo
           format: table


### PR DESCRIPTION
## Summary

- Renames the trailing version comment on the two `aquasecurity/trivy-action` SHA pins in `.github/workflows/security.yml` from bare-numeric (`# 0.35.0`) to the canonical `v`-prefixed form (`# v0.35.0`) on lines 101 and 115.
- The pinned SHA `57a97c7e7821a5776cebc9bb87c984fa69cba8f1` is unchanged; it already resolves to upstream tag `v0.35.0`. This is a comment-only change with no behavioral or security delta.

## Why

zizmor's `ref-version-mismatch` rule flagged both pins on PR #182 (Dependabot bump to `0.36.0`):
- https://github.com/j7an/nexus-mcp/security/code-scanning/38 (line 101)
- https://github.com/j7an/nexus-mcp/security/code-scanning/39 (line 115)

The bare-numeric comment style does not name a real upstream tag (the upstream tags are `v0.35.0` / `v0.36.0`, not `0.35.0` / `0.36.0`). Dependabot inherits the comment style during bumps, so the bare form propagates and re-triggers zizmor on every dependency PR until canonicalized at the source. Modeled directly on dep-rank commit `16edb0c` which resolved the identical defect.

## Follow-up after merge

Per acceptance criterion 4 in #183, **PR #182 must be rebased on this branch after merge** so its post-bump comment lands as `# v0.36.0` (not `# 0.36.0`) and its two zizmor code-scanning comments clear. Recommend rebasing #182 immediately after merging this PR; if Dependabot doesn't auto-resolve, comment `@dependabot rebase` on #182.

## Test plan

- [ ] CI green on `fix/zizmor-trivy-pin` (pre-commit + Zizmor + Trivy + CodeQL + TruffleHog jobs all pass)
- [ ] Zizmor job in this PR's run produces zero `ref-version-mismatch` findings on `security.yml`
- [ ] Local check: `grep -rEn 'uses:.*@[a-f0-9]{40} # [0-9]' .github/workflows/` returns empty (verified pre-push: no matches)
- [ ] After merge: rebase #182 and confirm its two code-scanning comments at lines 101/115 clear

Closes #183.