### PR TITLE
feat: add Gemini model fallback on retryable errors

### DIFF
--- a/src/nexus_mcp/config.py
+++ b/src/nexus_mcp/config.py
@@ -17,6 +17,7 @@ __all__ = [
     "get_cli_detection_timeout",
     "get_runner_defaults",
     "get_runner_models",
+    "get_agent_fallback_models",
     "get_agent_env",
 ]
 
@@ -40,6 +41,9 @@ from nexus_mcp.config_resolver import (
 )
 from nexus_mcp.config_resolver import (
     get_agent_env as get_agent_env,
+)
+from nexus_mcp.config_resolver import (
+    get_agent_fallback_models as get_agent_fallback_models,
 )
 from nexus_mcp.config_resolver import (
     get_runner_defaults as get_runner_defaults,

--- a/src/nexus_mcp/config_resolver.py
+++ b/src/nexus_mcp/config_resolver.py
@@ -196,6 +196,14 @@ def get_runner_models(runner_name: str) -> tuple[str, ...]:
     return tuple(m.strip() for m in raw.split(",") if m.strip())
 
 
+def get_agent_fallback_models(agent: str) -> tuple[str, ...]:
+    """Get fallback model list for an agent from NEXUS_{AGENT}_FALLBACK_MODELS."""
+    raw = os.getenv(f"NEXUS_{agent.upper()}_FALLBACK_MODELS")
+    if not raw:
+        return ()
+    return tuple(model.strip() for model in raw.split(",") if model.strip())
+
+
 # ---------------------------------------------------------------------------
 # Per-runner defaults (3-tier merge)
 # ---------------------------------------------------------------------------

--- a/src/nexus_mcp/runners/base.py
+++ b/src/nexus_mcp/runners/base.py
@@ -123,7 +123,18 @@ class AbstractRunner(RetryMixin, ABC):
     async def _execute(
         self, request: PromptRequest, emit: LogEmitter, progress: ProgressEmitter
     ) -> AgentResponse:
-        """Execute CLI agent once using Template Method pattern.
+        """Execute one runner-level attempt.
+
+        The default implementation is exactly one subprocess/parse/recovery pass.
+        Gemini overrides this method so one runner-level attempt can span multiple
+        models in a fallback chain.
+        """
+        return await self._execute_single_attempt(request, emit, progress)
+
+    async def _execute_single_attempt(
+        self, request: PromptRequest, emit: LogEmitter, progress: ProgressEmitter
+    ) -> AgentResponse:
+        """Execute exactly one subprocess attempt for the given request.
 
         Template steps:
         1. build_command(request) → command list

--- a/src/nexus_mcp/runners/gemini.py
+++ b/src/nexus_mcp/runners/gemini.py
@@ -15,10 +15,11 @@ import contextlib
 import json
 from typing import Any, ClassVar
 
-from nexus_mcp.exceptions import ParseError
+from nexus_mcp.config import get_agent_fallback_models
+from nexus_mcp.exceptions import ParseError, RetryableError
 from nexus_mcp.parser import extract_last_json_array, extract_last_json_object
 from nexus_mcp.runners.base import AbstractRunner
-from nexus_mcp.types import AgentResponse, ExecutionMode, PromptRequest
+from nexus_mcp.types import AgentResponse, ExecutionMode, LogEmitter, ProgressEmitter, PromptRequest
 
 
 class GeminiRunner(AbstractRunner):
@@ -157,6 +158,32 @@ class GeminiRunner(AbstractRunner):
         Raises:
             SubprocessError: If stdout or stderr contains a Gemini API error object.
         """
+        data = self._extract_error_payload(stdout, stderr)
+        if data is None:
+            return
+
+        error = data["error"]  # _extract_error_payload guarantees this is a dict
+        code = self._coerce_error_code(error.get("code", "unknown"))
+        message = error.get("message", "unknown error")
+        status = error.get("status", "")
+        if code == 1 and message == "[object Object]":
+            return
+        error_msg = f"Gemini API error {code}: {message} ({status})"
+        self._raise_structured_error(error_msg, code, stdout, stderr, returncode, command)
+
+    # ------------------------------------------------------------------
+    # Fallback-chain helpers
+    # ------------------------------------------------------------------
+
+    def _resolve_primary_model(self, request: PromptRequest) -> str | None:
+        return request.model or self.default_model
+
+    def _extract_error_payload(self, stdout: str, stderr: str) -> dict[str, Any] | None:
+        """Locate a Gemini error JSON object in stdout (preferred) or stderr.
+
+        Returns the parent dict whose ``error`` field is a dict, or None if no
+        such payload exists.
+        """
         data: dict[str, Any] | None = None
         with contextlib.suppress(json.JSONDecodeError):
             parsed = json.loads(stdout)
@@ -169,16 +196,97 @@ class GeminiRunner(AbstractRunner):
             data = extract_last_json_object(stderr)
 
         if data is None:
-            return
+            return None
 
         error = data.get("error")
         if not isinstance(error, dict):
-            return
+            return None
+        return data
 
-        code = self._coerce_error_code(error.get("code", "unknown"))
-        message = error.get("message", "unknown error")
-        status = error.get("status", "")
-        if code == 1 and message == "[object Object]":
-            return
-        error_msg = f"Gemini API error {code}: {message} ({status})"
-        self._raise_structured_error(error_msg, code, stdout, stderr, returncode, command)
+    def _build_fallback_chain(self, primary_model: str) -> tuple[str, ...]:
+        """Build the ordered fallback chain starting from the primary model.
+
+        Deduplicates while preserving first-seen order so each model is tried
+        at most once per runner-level attempt.
+        """
+        seen: set[str] = set()
+        ordered: list[str] = []
+        for model in (primary_model, *get_agent_fallback_models(self.AGENT_NAME)):
+            if model not in seen:
+                ordered.append(model)
+                seen.add(model)
+        return tuple(ordered)
+
+    def _with_effective_model_metadata(
+        self,
+        response: AgentResponse,
+        *,
+        original_model: str,
+        effective_model: str,
+        fallback_attempt: int,
+        fallback_reason: str | None,
+    ) -> AgentResponse:
+        """Stamp fallback bookkeeping onto a successful response."""
+        metadata: dict[str, object] = {
+            "effective_model": effective_model,
+            "fallback_model_used": effective_model != original_model,
+            "original_model": original_model,
+        }
+        if effective_model != original_model:
+            metadata["fallback_attempt"] = fallback_attempt
+            if fallback_reason:
+                metadata["fallback_reason"] = fallback_reason
+        return response.with_metadata(**metadata)
+
+    def _retryable_reason(self, error: RetryableError | None) -> str | None:
+        """Best-effort summary of why the previous model in the chain failed."""
+        if error is None:
+            return None
+        data = self._extract_error_payload(error.stdout, error.stderr)
+        if data is None:
+            return str(error)
+        status = data["error"].get("status")
+        if isinstance(status, str) and status:
+            return status
+        return str(error)
+
+    async def _execute(
+        self, request: PromptRequest, emit: LogEmitter, progress: ProgressEmitter
+    ) -> AgentResponse:
+        """Walk the fallback model chain on retryable failures.
+
+        For a single runner-level attempt, try each model in order. A
+        ``RetryableError`` from one model triggers an immediate switch to the
+        next; non-retryable errors propagate as before. The first success is
+        returned with fallback metadata stamped on the response.
+        """
+        primary_model = self._resolve_primary_model(request)
+        if primary_model is None:
+            return await self._execute_single_attempt(request, emit, progress)
+
+        chain = self._build_fallback_chain(primary_model)
+        last_retryable: RetryableError | None = None
+
+        for index, model in enumerate(chain, start=1):
+            attempt_request = request.model_copy(update={"model": model})
+            try:
+                response = await self._execute_single_attempt(attempt_request, emit, progress)
+                reason = self._retryable_reason(last_retryable) if last_retryable else None
+                return self._with_effective_model_metadata(
+                    response,
+                    original_model=primary_model,
+                    effective_model=model,
+                    fallback_attempt=index,
+                    fallback_reason=reason,
+                )
+            except RetryableError as error:
+                last_retryable = error
+                if index == len(chain):
+                    raise
+                await emit(
+                    "warning",
+                    f"Gemini retryable error on model {model}; "
+                    f"switching to fallback model {chain[index]}",
+                )
+        # Unreachable: loop always returns or raises — satisfies type checker
+        raise AssertionError("unreachable: fallback loop exited without result or exception")

--- a/src/nexus_mcp/runners/gemini.py
+++ b/src/nexus_mcp/runners/gemini.py
@@ -11,12 +11,13 @@ Expected JSON response:
     {"response": "...", "stats": {...}}  # stats field is optional
 """
 
+import asyncio
 import contextlib
 import json
 from typing import Any, ClassVar
 
 from nexus_mcp.config import get_agent_fallback_models
-from nexus_mcp.exceptions import ParseError, RetryableError
+from nexus_mcp.exceptions import ParseError, RetryableError, SubprocessTimeoutError
 from nexus_mcp.parser import extract_last_json_array, extract_last_json_object
 from nexus_mcp.runners.base import AbstractRunner
 from nexus_mcp.types import AgentResponse, ExecutionMode, LogEmitter, ProgressEmitter, PromptRequest
@@ -288,5 +289,10 @@ class GeminiRunner(AbstractRunner):
                     f"Gemini retryable error on model {model}; "
                     f"switching to fallback model {chain[index]}",
                 )
+                continue
+            except SubprocessTimeoutError:
+                raise
+            except asyncio.CancelledError:
+                raise
         # Unreachable: loop always returns or raises — satisfies type checker
         raise AssertionError("unreachable: fallback loop exited without result or exception")

--- a/src/nexus_mcp/server.py
+++ b/src/nexus_mcp/server.py
@@ -312,9 +312,12 @@ async def batch_prompt(
             if t.cli is None:
                 raise ToolError("cli is required on all tasks when no context available")
 
-    def _metadata_header(task: AgentTask) -> str:
+    def _metadata_header(task: AgentTask, metadata: dict[str, Any] | None = None) -> str:
         """Build a short metadata line so the AI knows which runner handled the task."""
-        model_part = task.model or "default"
+        metadata = metadata or {}
+        model_part = metadata.get("effective_model") or task.model or "default"
+        if metadata.get("fallback_model_used") is True and metadata.get("original_model"):
+            model_part = f"{model_part} (fallback from {metadata['original_model']})"
         return f"[cli: {task.cli} | model: {model_part} | mode: {task.execution_mode}]"
 
     labelled = assign_labels(tasks)
@@ -342,7 +345,7 @@ async def batch_prompt(
                 request = task.to_request()
                 runner = RunnerFactory.create(request.cli)
                 response = await runner.run(request, emitter=emitter, progress=progress)
-                header = _metadata_header(task)
+                header = _metadata_header(task, response.metadata)
                 output = f"{header}\n\n{response.output}"
                 return AgentTaskResult(label=task.label, output=output)  # type: ignore[arg-type]
             except Exception as e:

--- a/tests/unit/runners/test_base.py
+++ b/tests/unit/runners/test_base.py
@@ -602,3 +602,38 @@ class TestRaiseStructuredError:
             )
         assert exc_info.value.stdout == "rate stdout"
         assert exc_info.value.stderr == "rate stderr"
+
+
+class TestAbstractRunnerSingleAttempt:
+    """Direct tests for the extracted single-attempt helper."""
+
+    @pytest.fixture
+    def runner(self) -> ConcreteRunner:
+        return ConcreteRunner()
+
+    @patch("nexus_mcp.process.asyncio.create_subprocess_exec")
+    async def test_execute_single_attempt_recovers_nonzero_exit(self, mock_exec, runner):
+        mock_exec.return_value = create_mock_process(
+            stdout="success output",
+            stderr="minor warning",
+            returncode=1,
+        )
+
+        response = await runner._execute_single_attempt(
+            make_prompt_request(prompt="test"),
+            AsyncMock(),
+            AsyncMock(),
+        )
+
+        assert response.output == "success output"
+        assert response.metadata["recovered_from_error"] is True
+        assert response.metadata["original_exit_code"] == 1
+
+    async def test_execute_delegates_to_single_attempt(self, runner):
+        expected = make_agent_response(output="ok")
+        runner._execute_single_attempt = AsyncMock(return_value=expected)  # type: ignore[method-assign]
+
+        response = await runner._execute(make_prompt_request(), AsyncMock(), AsyncMock())
+
+        assert response == expected
+        runner._execute_single_attempt.assert_awaited_once()

--- a/tests/unit/runners/test_gemini.py
+++ b/tests/unit/runners/test_gemini.py
@@ -1065,3 +1065,78 @@ class TestGeminiRunnerFallbackSuccess:
 
         models = [call.args[call.args.index("--model") + 1] for call in mock_exec.call_args_list]
         assert models == ["gemini-3.1-pro-preview", "gemini-3-flash-preview"]
+
+
+# ---------------------------------------------------------------------------
+# Fallback chain — retry semantics
+# ---------------------------------------------------------------------------
+
+
+class TestGeminiRunnerFallbackRetrySemantics:
+    """Fallback should only advance on RetryableError."""
+
+    @patch.dict(
+        "os.environ",
+        {"NEXUS_GEMINI_FALLBACK_MODELS": "gemini-3-flash-preview"},
+        clear=False,
+    )
+    @patch("nexus_mcp.process.asyncio.create_subprocess_exec")
+    async def test_full_chain_retryable_exhaustion_retries_whole_chain(self, mock_exec):
+        error_stdout = gemini_error_json(429, "Quota exhausted", "RESOURCE_EXHAUSTED")
+        mock_exec.return_value = create_mock_process(stdout=error_stdout, returncode=1)
+
+        runner = make_gemini_runner()
+        request = make_prompt_request(model="gemini-3.1-pro-preview", max_retries=2)
+
+        with pytest.raises(RetryableError):
+            await runner.run(request)
+
+        models = [call.args[call.args.index("--model") + 1] for call in mock_exec.call_args_list]
+        assert models == [
+            "gemini-3.1-pro-preview",
+            "gemini-3-flash-preview",
+            "gemini-3.1-pro-preview",
+            "gemini-3-flash-preview",
+        ]
+
+    @patch.dict(
+        "os.environ",
+        {"NEXUS_GEMINI_FALLBACK_MODELS": "gemini-3-flash-preview"},
+        clear=False,
+    )
+    @patch("nexus_mcp.process.asyncio.create_subprocess_exec")
+    async def test_non_retryable_error_does_not_advance_to_fallback(self, mock_exec):
+        mock_exec.return_value = create_mock_process(
+            stdout=gemini_error_json(401, "Bad API key", "UNAUTHENTICATED"),
+            returncode=1,
+        )
+
+        runner = make_gemini_runner()
+
+        with pytest.raises(SubprocessError):
+            await runner.run(make_prompt_request(model="gemini-3.1-pro-preview", max_retries=2))
+
+        assert mock_exec.await_count == 1
+
+    @patch.dict(
+        "os.environ",
+        {"NEXUS_GEMINI_FALLBACK_MODELS": "gemini-3-flash-preview"},
+        clear=False,
+    )
+    @patch("nexus_mcp.process.asyncio.create_subprocess_exec")
+    async def test_no_primary_model_keeps_existing_retry_only_behavior(self, mock_exec):
+        mock_exec.side_effect = [
+            create_mock_process(
+                stdout=gemini_error_json(429, "Rate limited", "RESOURCE_EXHAUSTED"),
+                returncode=1,
+            ),
+            create_mock_process(stdout=gemini_json("ok after retry"), returncode=0),
+        ]
+
+        runner = make_gemini_runner()
+        response = await runner.run(make_prompt_request(model=None, max_retries=2))
+
+        assert response.output == "ok after retry"
+        assert response.metadata == {}
+        for call in mock_exec.call_args_list:
+            assert "--model" not in list(call.args)

--- a/tests/unit/runners/test_gemini.py
+++ b/tests/unit/runners/test_gemini.py
@@ -21,6 +21,7 @@ from tests.fixtures import (
     GEMINI_NOISY_STDOUT,
     create_mock_process,
     gemini_error_json,
+    gemini_json,
     make_prompt_request,
 )
 
@@ -986,3 +987,81 @@ class TestGaxiosErrorExtraction:
 class TestGeminiRunnerClassConstants:
     def test_supported_modes_class_constant(self):
         assert GeminiRunner._SUPPORTED_MODES == ("default", "yolo")
+
+
+# ---------------------------------------------------------------------------
+# Fallback chain — success path
+# ---------------------------------------------------------------------------
+
+
+class TestGeminiRunnerFallbackSuccess:
+    """Retryable primary failure should switch models immediately."""
+
+    @patch.dict(
+        "os.environ",
+        {"NEXUS_GEMINI_FALLBACK_MODELS": ("gemini-3.1-pro-preview,gemini-3-flash-preview")},
+        clear=False,
+    )
+    @patch("nexus_mcp.process.asyncio.create_subprocess_exec")
+    async def test_retryable_primary_failure_switches_to_fallback_model(self, mock_exec):
+        mock_exec.side_effect = [
+            create_mock_process(
+                stdout=gemini_error_json(429, "No capacity", "RESOURCE_EXHAUSTED"),
+                returncode=1,
+            ),
+            create_mock_process(
+                stdout=gemini_json(
+                    "fallback output",
+                    {"models": {"gemini-3-flash-preview": 1}},
+                ),
+                returncode=0,
+            ),
+        ]
+        calls: list[tuple[str, str]] = []
+
+        async def collecting_emitter(level: str, message: str) -> None:
+            calls.append((level, message))
+
+        runner = make_gemini_runner()
+        response = await runner.run(
+            make_prompt_request(model="gemini-3.1-pro-preview", max_retries=1),
+            emitter=collecting_emitter,
+        )
+
+        models = [call.args[call.args.index("--model") + 1] for call in mock_exec.call_args_list]
+        assert models == ["gemini-3.1-pro-preview", "gemini-3-flash-preview"]
+        assert response.metadata["effective_model"] == "gemini-3-flash-preview"
+        assert response.metadata["fallback_model_used"] is True
+        assert response.metadata["original_model"] == "gemini-3.1-pro-preview"
+        assert response.metadata["fallback_attempt"] == 2
+        assert response.metadata["fallback_reason"] == "RESOURCE_EXHAUSTED"
+        assert any(
+            "switching to fallback model gemini-3-flash-preview" in msg
+            for level, msg in calls
+            if level == "warning"
+        )
+
+    @patch.dict(
+        "os.environ",
+        {
+            "NEXUS_GEMINI_FALLBACK_MODELS": (
+                "gemini-3.1-pro-preview,gemini-3-flash-preview,gemini-3-flash-preview"
+            )
+        },
+        clear=False,
+    )
+    @patch("nexus_mcp.process.asyncio.create_subprocess_exec")
+    async def test_fallback_chain_deduplicates_while_preserving_order(self, mock_exec):
+        mock_exec.side_effect = [
+            create_mock_process(
+                stdout=gemini_error_json(429, "No capacity", "RESOURCE_EXHAUSTED"),
+                returncode=1,
+            ),
+            create_mock_process(stdout=gemini_json("ok from fallback"), returncode=0),
+        ]
+
+        runner = make_gemini_runner()
+        await runner.run(make_prompt_request(model="gemini-3.1-pro-preview", max_retries=1))
+
+        models = [call.args[call.args.index("--model") + 1] for call in mock_exec.call_args_list]
+        assert models == ["gemini-3.1-pro-preview", "gemini-3-flash-preview"]

--- a/tests/unit/runners/test_gemini.py
+++ b/tests/unit/runners/test_gemini.py
@@ -8,12 +8,18 @@ Tests verify:
 """
 
 import asyncio
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from nexus_mcp.cli_detector import CLIInfo
-from nexus_mcp.exceptions import CLINotFoundError, ParseError, RetryableError, SubprocessError
+from nexus_mcp.exceptions import (
+    CLINotFoundError,
+    ParseError,
+    RetryableError,
+    SubprocessError,
+    SubprocessTimeoutError,
+)
 from nexus_mcp.runners.gemini import GeminiRunner
 from tests.fixtures import (
     GEMINI_JSON_RESPONSE,
@@ -1140,3 +1146,62 @@ class TestGeminiRunnerFallbackRetrySemantics:
         assert response.metadata == {}
         for call in mock_exec.call_args_list:
             assert "--model" not in list(call.args)
+
+
+class TestGeminiRunnerFallbackRecoveryAndAbort:
+    """Recovered success should keep fallback attribution; timeout/cancel should abort."""
+
+    @patch.dict(
+        "os.environ",
+        {"NEXUS_GEMINI_FALLBACK_MODELS": "gemini-3-flash-preview"},
+        clear=False,
+    )
+    @patch("nexus_mcp.process.asyncio.create_subprocess_exec")
+    async def test_recovered_fallback_response_keeps_fallback_metadata(self, mock_exec):
+        mock_exec.side_effect = [
+            create_mock_process(
+                stdout=gemini_error_json(429, "No capacity", "RESOURCE_EXHAUSTED"),
+                returncode=1,
+            ),
+            create_mock_process(
+                stdout=gemini_json("partial fallback output"),
+                stderr="warning from fallback",
+                returncode=1,
+            ),
+        ]
+
+        runner = make_gemini_runner()
+        response = await runner.run(
+            make_prompt_request(model="gemini-3.1-pro-preview", max_retries=1)
+        )
+
+        assert response.output == "partial fallback output"
+        assert response.metadata["recovered_from_error"] is True
+        assert response.metadata["effective_model"] == "gemini-3-flash-preview"
+        assert response.metadata["fallback_model_used"] is True
+        assert response.metadata["original_model"] == "gemini-3.1-pro-preview"
+
+    async def test_timeout_aborts_without_advancing_chain(self):
+        runner = make_gemini_runner()
+        timeout = SubprocessTimeoutError(
+            "timed out",
+            timeout=30,
+            command=["gemini", "-p", "test"],
+        )
+        runner._execute_single_attempt = AsyncMock(side_effect=timeout)  # type: ignore[method-assign]
+
+        with pytest.raises(SubprocessTimeoutError):
+            await runner.run(make_prompt_request(model="gemini-3.1-pro-preview", max_retries=1))
+
+        assert runner._execute_single_attempt.await_count == 1
+
+    async def test_cancellation_aborts_without_advancing_chain(self):
+        runner = make_gemini_runner()
+        runner._execute_single_attempt = AsyncMock(  # type: ignore[method-assign]
+            side_effect=asyncio.CancelledError()
+        )
+
+        with pytest.raises(asyncio.CancelledError):
+            await runner.run(make_prompt_request(model="gemini-3.1-pro-preview", max_retries=1))
+
+        assert runner._execute_single_attempt.await_count == 1

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -13,6 +13,7 @@ from nexus_mcp.config import (
     _read_global_env_defaults,
     _read_runner_env_defaults,
     get_agent_env,
+    get_agent_fallback_models,
     get_cli_detection_timeout,
     get_global_output_limit,
     get_global_timeout,
@@ -650,6 +651,31 @@ class TestGetRunnerModels:
     def test_empty_string_returns_empty(self, monkeypatch):
         monkeypatch.setenv("NEXUS_GEMINI_MODELS", "")
         assert get_runner_models("gemini") == ()
+
+
+class TestGetAgentFallbackModels:
+    """Test get_agent_fallback_models() env parsing."""
+
+    @patch.dict(
+        os.environ,
+        {
+            "NEXUS_GEMINI_FALLBACK_MODELS": (
+                " gemini-3-flash-preview ,Gemini-3-Flash-Preview,, gemini-2.5-flash "
+            )
+        },
+        clear=False,
+    )
+    def test_preserves_exact_strings_after_whitespace_strip(self):
+        assert get_agent_fallback_models("gemini") == (
+            "gemini-3-flash-preview",
+            "Gemini-3-Flash-Preview",
+            "gemini-2.5-flash",
+        )
+
+    @patch.dict(os.environ, {}, clear=False)
+    def test_returns_empty_tuple_when_env_var_missing(self):
+        os.environ.pop("NEXUS_GEMINI_FALLBACK_MODELS", None)
+        assert get_agent_fallback_models("gemini") == ()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_server_gemini_pipeline.py
+++ b/tests/unit/test_server_gemini_pipeline.py
@@ -10,6 +10,7 @@ and runner tests (mock at subprocess) independently miss.
 """
 
 import json
+from unittest.mock import patch
 
 import pytest
 from fastmcp.exceptions import ToolError
@@ -145,6 +146,33 @@ class TestPromptGeminiPipeline:
             await prompt(cli="gemini", prompt="test", max_retries=3)
 
         assert mock_subprocess.call_count == 3
+
+    @patch.dict(
+        "os.environ",
+        {"NEXUS_GEMINI_FALLBACK_MODELS": "gemini-3-flash-preview"},
+        clear=False,
+    )
+    async def test_fallback_header_shows_effective_model_and_origin(self, mock_subprocess):
+        mock_subprocess.side_effect = [
+            create_mock_process(
+                stdout=_gemini_error_json(429, "Resource exhausted", "RESOURCE_EXHAUSTED"),
+                returncode=1,
+            ),
+            create_mock_process(stdout=_gemini_json("ok from fallback"), returncode=0),
+        ]
+
+        result = await prompt(
+            cli="gemini",
+            prompt="test",
+            model="gemini-3.1-pro-preview",
+            max_retries=1,
+        )
+
+        assert result.startswith(
+            "[cli: gemini | model: gemini-3-flash-preview "
+            "(fallback from gemini-3.1-pro-preview) | mode: default]\n\n"
+        )
+        assert strip_runner_header(result) == "ok from fallback"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds opt-in Gemini-only model failover when a retryable error (e.g. `RESOURCE_EXHAUSTED`) hits the requested model. Configured via `NEXUS_GEMINI_FALLBACK_MODELS` (comma-separated, ordered, deduplicated).
- One Gemini `_execute()` call now encapsulates one full fallback-chain pass; the existing shared retry loop continues to apply backoff across whole-chain attempts.
- The MCP response header now reflects the effective model: `[cli: gemini | model: gemini-3-flash-preview (fallback from gemini-3.1-pro-preview) | mode: default]` when fallback fires; non-fallback responses keep today's shape.

Spec: `docs/superpowers/specs/2026-05-03-gemini-model-fallback-design.md` (local-only, not committed).

### Implementation shape

- `config.get_agent_fallback_models("gemini")` parses the env var.
- `AbstractRunner._execute_single_attempt()` extracted from `_execute()` so Gemini can call it per model.
- `GeminiRunner._execute()` overrides the default to walk the deduplicated fallback chain on `RetryableError`, abort immediately on non-retryable / `SubprocessTimeoutError` / `asyncio.CancelledError`, and stamp `effective_model` / `fallback_model_used` / `original_model` (plus optional `fallback_attempt` / `fallback_reason`) onto the response.
- `server._metadata_header()` renders the effective model from response metadata, falling back to the requested model when metadata is absent.

### Behavior summary

| Condition | Behavior |
|-----------|----------|
| Primary model succeeds | Return immediately; metadata reflects primary as effective model |
| `RetryableError` on primary | Switch to next model immediately, no delay |
| Non-retryable error | Raise; do not advance fallback chain |
| Timeout / cancellation | Raise; do not advance fallback chain |
| All models fail retryably | Re-raise last `RetryableError`; outer retry loop applies backoff and retries the whole chain |
| No primary model resolvable | Skip fallback entirely; existing retry-only behavior preserved |
| Recovered response on fallback model | Keep `recovered_from_error=True` AND stamp fallback metadata |

## Test plan

- [x] `tests/unit/test_config.py` — `NEXUS_GEMINI_FALLBACK_MODELS` parsing (whitespace strip, exact-string preservation, empty-tuple default)
- [x] `tests/unit/runners/test_base.py` — extracted `_execute_single_attempt()` + delegation
- [x] `tests/unit/runners/test_gemini.py` — fallback success, ordered dedup, retry semantics, recovery, timeout/cancel abort, switch-warning emit
- [x] `tests/unit/test_server_gemini_pipeline.py` — header reflects effective model and `(fallback from <primary>)` suffix
- [x] Full suite: 1250 passed (unit + e2e), ruff + mypy clean
- [ ] Reviewer-flagged follow-up: `_retryable_reason()` falls through to `str(error)` when status is missing, which produces multi-pipe debug detail in `metadata["fallback_reason"]`. The plan prescribed this exact shape; surfaced for awareness, not blocking.

Fixes #11.