### PR TITLE
fix(deps): bump python-multipart to 0.0.29 for CVE-2026-42561

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1365,11 +1365,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.22"
+version = "0.0.29"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/fe/70bd71a6738b09a0bdf6480ca6436b167469ca4578b2a0efbe390b4b0e70/python_multipart-0.0.29.tar.gz", hash = "sha256:643e93849196645e2dbdd81a0f8829a23123ad7f797a84a364c6fb3563f18904", size = 45678, upload-time = "2026-05-17T17:29:47.654Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/cb/769cfc37177252872a45a71f3fbdde9d51b471a3f3c14bfe95dde3407386/python_multipart-0.0.29-py3-none-any.whl", hash = "sha256:2ddcc971cef266225f54f552d8fa10bcfbb1f14446caec199060daac59ff2d69", size = 29640, upload-time = "2026-05-17T17:29:45.69Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bumps `python-multipart` 0.0.22 → 0.0.29 to resolve **CVE-2026-42561** (HIGH; fixed upstream in 0.0.27).
- Only an `uv.lock` change — `python-multipart` is a transitive of `mcp` → `fastmcp`, no direct declaration in `pyproject.toml`.

Detected by the scheduled Trivy scan on `main` (run [26395527430](https://github.com/j7an/nexus-mcp/actions/runs/26395527430), failing step "Fail on CRITICAL/HIGH vulnerabilities").

## Out of scope
The same scan also flagged **CVE-2026-34444** in `lupa@2.6` (HIGH). Trivy's DB lists no fixed version, and `lupa` is an unreachable transitive (`pydocket` → `fakeredis[lua]`; `nexus-mcp` never imports/executes Lua — verified via `grep -rn 'lupa\|lua_script\|run_lua' src tests`). That CVE will be addressed in a follow-up, likely via a scoped `.trivyignore` entry once we confirm `lupa@2.8` doesn't clear the advisory either.

This PR's Trivy CI job will therefore **still fail** on the lupa finding — expected, and tracked separately.

## Test plan
- [x] `uv run pytest -m "not integration"` — 1254 passed.
- [x] `uv run mypy src/nexus_mcp` — clean.
- [x] `uv run ruff check .` — clean.
- [ ] CI confirms python-multipart finding is gone (lupa finding will remain).