### PR TITLE
fix(deps): apply 1-week uv exclude-newer cooldown

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,3 +151,6 @@ exclude_also = [
     "class .*\\bProtocol\\):",
     "\\.\\.\\.",
 ]
+
+[tool.uv]
+exclude-newer = "1 week"

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,10 @@ resolution-markers = [
     "python_full_version < '3.15'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P1W"
+
 [[package]]
 name = "aiofile"
 version = "3.9.0"


### PR DESCRIPTION
## Summary
- Adds `[tool.uv].exclude-newer = "1 week"` to `pyproject.toml`
- Regenerates `uv.lock` under the new cutoff (no package versions moved — current lock already satisfies the 7-day rule)
- Mirrors the existing 5-day Dependabot cooldown for ad-hoc `uv lock` / `uv sync` runs by humans or CI

## Test plan
- [x] `uv lock` regenerates cleanly (cutoff resolved to 2026-05-18)
- [x] `uv sync --locked --all-extras --all-groups` exits 0
- [x] `uv run pytest -m "not integration"` — 1254 passed, 18 deselected
- [x] `uv run ruff check .` — all checks passed
- [x] `uv run mypy src/nexus_mcp` — no issues found in 38 source files

Fixes #197.