### PR TITLE
fix(deps): bump shared-workflows v2.6.0 → v3.0.1

### DIFF
--- a/.github/workflows/dependency-safety.yml
+++ b/.github/workflows/dependency-safety.yml
@@ -16,6 +16,6 @@ concurrency:
 
 jobs:
   safety:
-    uses: j7an/shared-workflows/.github/workflows/dependency-safety.yml@704d0b58e2093d238c7389756974efd2ce582d20 # v2.6.0
+    uses: j7an/shared-workflows/.github/workflows/dependency-safety.yml@522610f12d08a8fe358569d6c533c21af6ac8ec0 # v3.0.1
     with:
       auto_merge: true


### PR DESCRIPTION
## Summary

Bumps `j7an/shared-workflows/.github/workflows/dependency-safety.yml` pin from `v2.6.0` to `v3.0.1`.

Crosses the v2 → v3 major-version boundary. v3.0.0 was a breaking change that removed the deprecated `dependency-cooldown.yml` and `cooldown-rescan.yml` workflows. This repo's only consumer of shared-workflows is `dependency-safety.yml` (verified: no cooldown references anywhere in `.github/`), so the migration is mechanical — no other workflows need touching.

Also picks up the clickable-gate fix (j7an/shared-workflows#77): the `dependency-safety / gate` status row now sets `target_url`, so the row links to the `safety / scan` job page from the PR checks panel.

## Test plan
- [ ] CI green on this PR
- [ ] On the next Dependabot PR, the `dependency-safety / gate` row is clickable from the checks panel
- [ ] Verify the gate still gates (passing/failing behavior unchanged)