### PR TITLE
fix(opencode): surface structured errors on zero exit; pin integration model

### DIFF
--- a/src/nexus_mcp/runners/base.py
+++ b/src/nexus_mcp/runners/base.py
@@ -194,7 +194,15 @@ class AbstractRunner(RetryMixin, ABC):
 
         # Step 4: Parse output
         await progress(4, 5, "Parsing output")
-        response = self.parse_output(result.stdout, result.stderr)
+        try:
+            response = self.parse_output(result.stdout, result.stderr)
+        except ParseError:
+            # A CLI may exit 0 while emitting a structured error event (e.g.
+            # OpenCode emits {"type":"error",...} on a 403/429 yet returns 0).
+            # Surface it as a structured error — raising RetryableError for
+            # retryable codes — before re-raising the generic ParseError.
+            self._try_extract_error(result.stdout, result.stderr, result.returncode, command)
+            raise
 
         # Step 5: Apply output limiting (stays sync — no signature change)
         await progress(5, 5, "Applying output limits")

--- a/src/nexus_mcp/runners/opencode.py
+++ b/src/nexus_mcp/runners/opencode.py
@@ -120,12 +120,15 @@ class OpenCodeRunner(AbstractRunner):
             stdout: Raw NDJSON output from OpenCode CLI.
 
         Returns:
-            Joined text from all text events, ``""`` if valid NDJSON was parsed
-            but contained no text events (e.g. tool-only runs), or ``None`` if
-            stdout is not NDJSON at all (triggers JSON fallback).
+            Joined text from all text events; ``None`` if an error event was
+            present with no text (falls through to error extraction) or if
+            stdout is not NDJSON at all (triggers JSON fallback); ``""`` if
+            valid NDJSON was parsed but contained no text and no error events
+            (e.g. tool-only runs).
         """
         parts: list[str] = []
         found_json_event = False
+        found_error_event = False
         for line in stdout.splitlines():
             if not line.strip():
                 continue
@@ -136,7 +139,8 @@ class OpenCodeRunner(AbstractRunner):
             if not isinstance(event, dict):
                 continue
             if event.get("type") == "error":
-                continue  # Skipped; _try_extract_error handles these on non-zero exit
+                found_error_event = True
+                continue  # Skipped; _try_extract_error handles these
             if "type" not in event:
                 continue  # Typeless dicts: skip sentinel, let JSON fallback handle them
             found_json_event = True
@@ -150,6 +154,8 @@ class OpenCodeRunner(AbstractRunner):
                 parts.append(text)
         if parts:
             return "\n\n".join(parts)
+        if found_error_event:
+            return None  # Error present with no text: fall through to error extraction.
         return "" if found_json_event else None
 
     def _parse_json_object(self, stdout: str) -> str | None:

--- a/tests/integration/test_opencode_runner.py
+++ b/tests/integration/test_opencode_runner.py
@@ -19,7 +19,9 @@ class TestOpenCodeRunnerIntegration:
 
     async def test_run_returns_valid_response(self, opencode_runner: OpenCodeRunner) -> None:
         """run() with real API returns AgentResponse with output and metadata."""
-        request = make_prompt_request(cli="opencode", prompt=PING_PROMPT)
+        request = make_prompt_request(
+            cli="opencode", prompt=PING_PROMPT, model="ollama-cloud/gpt-oss:20b"
+        )
         response = await opencode_runner.run(request)
 
         assert isinstance(response, AgentResponse)

--- a/tests/unit/runners/test_opencode.py
+++ b/tests/unit/runners/test_opencode.py
@@ -862,3 +862,29 @@ class TestOpenCodeRunnerErrorOnZeroExit:
 
         with pytest.raises(RetryableError):
             await runner.run(make_prompt_request(cli="opencode", prompt="x", max_retries=1))
+
+    def test_lifecycle_then_error_does_not_parse_as_empty_success(self):
+        """Lifecycle event before an error event → ParseError, not empty success.
+
+        A non-text lifecycle event (step_start) must not mark the stream as a
+        valid empty (tool-only) run when an error event is also present, or the
+        structured error is silently swallowed as output="".
+        """
+        stdout = '{"type": "step_start", "sessionID": "s"}\n' + opencode_error_json(
+            "ServiceError", "unavailable", status_code=503
+        )
+        runner = make_opencode_runner()
+        with pytest.raises(ParseError):
+            runner.parse_output(stdout, "")
+
+    @patch("nexus_mcp.process.asyncio.create_subprocess_exec")
+    async def test_error_after_lifecycle_event_surfaces_when_cli_exits_zero(self, mock_exec):
+        """Exit 0 + lifecycle event + error NDJSON → RetryableError, not empty success."""
+        stdout = '{"type": "step_start", "sessionID": "s"}\n' + opencode_error_json(
+            "ServiceError", "unavailable", status_code=503
+        )
+        mock_exec.return_value = create_mock_process(stdout=stdout, stderr="", returncode=0)
+        runner = make_opencode_runner()
+
+        with pytest.raises(RetryableError):
+            await runner.run(make_prompt_request(cli="opencode", prompt="x", max_retries=1))

--- a/tests/unit/runners/test_opencode.py
+++ b/tests/unit/runners/test_opencode.py
@@ -817,3 +817,48 @@ class TestOpenCodeTryExtractErrorBranches:
         with pytest.raises(SubprocessError) as exc_info:
             runner._try_extract_error(stdout, "", 1)
         assert "AuthError" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Structured errors on zero exit code (CLI exits 0 while emitting error event)
+# ---------------------------------------------------------------------------
+
+
+class TestOpenCodeRunnerErrorOnZeroExit:
+    """OpenCode CLI can emit a {"type":"error"} event yet exit 0.
+
+    The error must still surface as a structured error (and retryable codes
+    must still be classified as RetryableError), not a generic ParseError.
+    """
+
+    @patch("nexus_mcp.process.asyncio.create_subprocess_exec")
+    async def test_structured_error_surfaces_when_cli_exits_zero(self, mock_exec):
+        """Exit 0 + error NDJSON → SubprocessError 'OpenCode API error', not ParseError."""
+        mock_exec.return_value = create_mock_process(
+            stdout=opencode_error_json(
+                "APIError", "Forbidden: subscription required", status_code=403
+            ),
+            stderr="",
+            returncode=0,
+        )
+        runner = make_opencode_runner()
+
+        with pytest.raises(SubprocessError) as exc_info:
+            await runner.run(make_prompt_request(cli="opencode", prompt="x", max_retries=1))
+
+        assert not isinstance(exc_info.value, ParseError)
+        assert "OpenCode API error" in exc_info.value.args[0]
+        assert "APIError" in exc_info.value.args[0]
+
+    @patch("nexus_mcp.process.asyncio.create_subprocess_exec")
+    async def test_retryable_error_classified_when_cli_exits_zero(self, mock_exec):
+        """Exit 0 + 503 error NDJSON → RetryableError (retryability preserved on clean exit)."""
+        mock_exec.return_value = create_mock_process(
+            stdout=opencode_error_json("ServiceError", "unavailable", status_code=503),
+            stderr="",
+            returncode=0,
+        )
+        runner = make_opencode_runner()
+
+        with pytest.raises(RetryableError):
+            await runner.run(make_prompt_request(cli="opencode", prompt="x", max_retries=1))


### PR DESCRIPTION
## Summary

Hardens the OpenCode runner's error handling and fixes an integration test that
broke when Ollama gated its cloud models behind a paid subscription. Three
related issues, found while diagnosing the failing OpenCode integration test and
during review.

## Changes

### 1. Structured errors lost when the CLI exits 0
OpenCode can emit a `{"type":"error",...}` NDJSON event while still **exiting 0**
(e.g. a 403/429 from the upstream model). The success path called `parse_output()`
with no error-recovery wrapper, so the error event was skipped and a misleading
`ParseError("No parseable output found in OpenCode CLI response")` was raised
instead of the real message. Retryable codes (429/503) were never classified as
`RetryableError`, so transient failures weren't retried.

Fix (`base.py`): make the exit-0 path symmetric with the existing non-zero path —
on `ParseError`, attempt structured error extraction (`_try_extract_error`) before
re-raising, reusing the existing retryable-code classification.

**Before:** `ParseError: No parseable output found in OpenCode CLI response`
**After:** `OpenCode API error APIError: Forbidden: this model requires a subscription, upgrade for access: ...`

### 2. Error after a lifecycle event silently swallowed (review finding)
`_parse_opencode_ndjson()` set `found_json_event` on any non-error typed event
(e.g. `step_start`). So an error stream **preceded by a lifecycle event** with no
text returned `""` (the legitimate tool-only sentinel) instead of `None` — which
made `parse_output()` return a *successful empty* `AgentResponse` and bypass the
exit-0 hook from change #1. A retryable 503 became a silent empty success, worse
than the original bug.

Fix (`opencode.py`): track error events separately. When no text is produced but
an error event is present, return `None` so `parse_output()` raises `ParseError`
and the error path classifies it (`RetryableError` for 429/503). The genuine
tool-only case (lifecycle events, no error, no text) still returns `""`.

### 3. Flaky integration test
`test_run_returns_valid_response` relied on OpenCode's mutable stored default
model (`ollama-cloud/kimi-k2.5`), which now returns 403. Pinned
`ollama-cloud/gpt-oss:20b` so the test no longer depends on external account state.

## Testing
- TDD for both code fixes: confirmed each new test fails (RED) against the old
  code and passes (GREEN) after the fix.
  - exit-0 error-only stdout → structured `SubprocessError` (403) / `RetryableError` (503)
  - exit-0 lifecycle-then-error stdout → `ParseError` at parse level, `RetryableError` through `run()`
  - preserved: tool-only NDJSON (lifecycle, no error, no text) still yields `output == ""`
- Full unit + e2e suite: **1170 passed**.
- `mypy` and `ruff`: clean.
- Verified end-to-end against the real OpenCode CLI: a 403 model now surfaces a
  structured `SubprocessError`, and the integration suite passes (4 passed, 11 skipped).

## Out of scope
Stdout with partial text **and** a trailing error still returns the partial text
as success (surfacing generated output). Error-wins-over-partial-text semantics
can follow up if desired.
