### PR TITLE
ci: add OSV-Scanner and Dependency Review to security pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,3 +117,25 @@ jobs:
       - uses: ./.github/actions/setup-uv
       - name: Mypy
         run: uv run mypy src/nexus_mcp
+
+  dependency-review:
+    name: Dependency Review
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Dependency Review
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: moderate
+          comment-summary-in-pr: never
+          # deny-licenses is deprecated upstream (actions/dependency-review-action#938) but
+          # still functional in v5.0.0. Identifiers use ClearlyDefined's short SPDX forms
+          # (the action's own examples use GPL-3.0 / LGPL-2.0). Revisit if removed in a future major.
+          deny-licenses: GPL-2.0, GPL-3.0, AGPL-3.0

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -118,3 +118,25 @@ jobs:
           format: table
           severity: CRITICAL,HIGH
           exit-code: "1"
+
+  osv-scan:
+    name: OSV-Scanner (full)
+    # Full recursive scan on push-to-main and the weekly schedule (not on PRs).
+    if: github.event_name == 'push' || github.event_name == 'schedule'
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+
+  osv-scan-pr:
+    name: OSV-Scanner (PR)
+    # PR diff scan with annotations for newly introduced vulnerabilities.
+    # merge_group intentionally excluded: the reusable PR workflow is PR-context-specific
+    # (uses $GITHUB_BASE_REF + pull_request.number) and would misbehave on merge_group. See issue #176.
+    if: github.event_name == 'pull_request'
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8


### PR DESCRIPTION
## Summary

Adds standard supply-chain checks alongside the existing `dependency-safety` workflow (#176):

- **OSV-Scanner** in `security.yml`:
  - `osv-scan` — full recursive scan on push-to-`main` and the weekly schedule.
  - `osv-scan-pr` — PR diff scan with annotations for newly introduced vulnerabilities.
  - Both call SHA-pinned reusable workflows @ `v2.3.8` (`9a49870`).
- **Dependency Review** in `ci.yml`: PR-only gate, `fail-on-severity: moderate`, denies `GPL-2.0`/`GPL-3.0`/`AGPL-3.0`, least-privilege `contents: read`. Pinned @ `v5.0.0` (`a1d282b`).

## Notes

- **`merge_group` intentionally deferred.** The OSV reusable PR workflow is PR-context-specific (uses `$GITHUB_BASE_REF` + `pull_request.number`) and would not scan a merge-queue payload correctly. The repo has no merge queue enabled today. To revisit if/when one is.
- `deny-licenses` is deprecated upstream (actions/dependency-review-action#938) but still functional in v5.0.0; identifiers use ClearlyDefined's short SPDX forms (matching the action's own examples). A code comment records this.
- Purely additive: **44 insertions, 0 deletions**. CodeQL, Trivy, Zizmor, TruffleHog, and `dependency-safety` are untouched.

## Verification

- `actionlint` and `zizmor --min-severity medium --min-confidence medium` show **no new findings** vs the pre-existing baseline.
- Both pinned tags dereference to the committed SHAs.

Fixes #176.
