### PR TITLE
ci: strengthen TestPyPI smoke test with version verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,13 @@ jobs:
               --index-url https://test.pypi.org/simple/ \
               --extra-index-url https://pypi.org/simple/ \
               "nexus-mcp==${VERSION}" 2>/dev/null; then
-              python -c "import nexus_mcp; print('TestPyPI install OK')"
+              ACTUAL=$(nexus-mcp --version 2>&1)
+              echo "Installed version: ${ACTUAL}"
+              if ! echo "${ACTUAL}" | grep -qF "${VERSION}"; then
+                echo "ERROR: Expected '${VERSION}' in nexus-mcp --version output"
+                exit 1
+              fi
+              echo "TestPyPI install OK"
               exit 0
             fi
             echo "Attempt $i: not yet available, retrying..."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,11 @@ jobs:
               --index-url https://test.pypi.org/simple/ \
               --extra-index-url https://pypi.org/simple/ \
               "nexus-mcp==${VERSION}" 2>/dev/null; then
-              ACTUAL=$(nexus-mcp --version 2>&1)
+              if ! ACTUAL=$(nexus-mcp --version 2>&1); then
+                echo "ERROR: 'nexus-mcp --version' failed to run:"
+                echo "${ACTUAL}"
+                exit 1
+              fi
               echo "Installed version: ${ACTUAL}"
               if ! echo "${ACTUAL}" | grep -qF "${VERSION}"; then
                 echo "ERROR: Expected '${VERSION}' in nexus-mcp --version output"


### PR DESCRIPTION
## What

Replace the TestPyPI smoke test's import-only check with a CLI version verification that confirms the installed package reports the expected version string.

Before:
```bash
python -c "import nexus_mcp; print('TestPyPI install OK')"
```

After:
```bash
ACTUAL=$(nexus-mcp --version 2>&1)
echo "Installed version: ${ACTUAL}"
if ! echo "${ACTUAL}" | grep -qF "${VERSION}"; then
  echo "ERROR: Expected '${VERSION}' in nexus-mcp --version output"
  exit 1
fi
echo "TestPyPI install OK"
```

## Why

The import-only check proves the import graph resolves but misses failures where the package ships wrong version metadata, the `nexus-mcp` console_script entry point is broken, or a dependency conflict crashes the CLI at startup while the library import still works.

## Acceptance Criteria

- [x] TestPyPI smoke test runs `nexus-mcp --version` after install
- [x] Version output is checked against `${VERSION}` (stripped from tag via `GITHUB_REF_NAME#v`)
- [x] Step fails with descriptive error if version doesn't match
- [x] Retry loop for TestPyPI propagation delay is preserved
- [x] Step still reports "TestPyPI install OK" on success

## Verification

- `actionlint` passes on the edited block (pre-existing SC2012 `ls` warnings on line 39 are unrelated).
- `nexus-mcp --version` is confirmed to print `nexus-mcp {__version__}` (`src/nexus_mcp/__main__.py:41-44`), so the `grep -qF "${VERSION}"` match holds.

Fixes #177.