### PR TITLE
ci: gate release builds on tests and label CodeQL SARIF

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,35 @@ permissions:
   contents: read
 
 jobs:
+  test:
+    name: Lint, typecheck, and test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: ./.github/actions/setup-uv
+
+      - name: Ruff check
+        run: uv run ruff check .
+
+      - name: Ruff format check
+        run: uv run ruff format --check .
+
+      - name: Mypy
+        run: uv run mypy src/nexus_mcp
+
+      - name: Run tests
+        run: uv run pytest -m "not integration"
+
   build:
     name: Build distributions
+    needs: [test]
     runs-on: ubuntu-latest
     steps:
       - name: Harden runner

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-uv
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -37,6 +37,8 @@ jobs:
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
+        with:
+          category: "/language:python"
 
   trufflehog:
     name: TruffleHog


### PR DESCRIPTION
## What

Tightens the release and security workflows:

1. Adds a release-only CI gate before building distributions in `.github/workflows/release.yml`.
2. Adds a CodeQL SARIF category label in `.github/workflows/security.yml`.

## Why

The release workflow verifies that the tag points to a commit on `main`, then builds and publishes artifacts. That proves the tagged commit is reachable from `main`, but it does not prove lint, typecheck, and tests passed for that exact tagged commit. The new `test` job makes broken tagged commits fail before package build or publish starts.

Setting `category: "/language:python"` on the CodeQL analyze step labels findings consistently in the Security tab alongside the other SARIF uploads (e.g. Trivy's `trivy` category).

## Changes

**`.github/workflows/release.yml`**

- New `test` job (hardened-runner → pinned `actions/checkout` → `./.github/actions/setup-uv`) running:
  - `uv run ruff check .`
  - `uv run ruff format --check .`
  - `uv run mypy src/nexus_mcp`
  - `uv run pytest -m "not integration"`
- `build` job now has `needs: [test]`.
- Tag-on-main verification, build/publish, TestPyPI, PyPI, GitHub Release, and MCP Registry jobs are otherwise unchanged.

**`.github/workflows/security.yml`**

- CodeQL analyze step now sets `with: category: "/language:python"`.

## Acceptance Criteria

- [x] `release.yml` has a `test` job that runs lint, format check, typecheck, and non-integration tests.
- [x] `release.yml` `build` job depends on the `test` job.
- [x] The release CI gate uses `./.github/actions/setup-uv`.
- [x] Existing release tag verification, build, TestPyPI, PyPI, GitHub Release, and MCP Registry jobs remain intact.
- [x] `security.yml` CodeQL analyze step sets `category: "/language:python"`.
- [x] `uv run ruff format --check .` and `uv run pytest -m "not integration"` are represented in the release gate.

Fixes #179.
