### PR TITLE
fix(ci): replace Dependabot lockfile auto-commit with loud drift failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,47 +12,7 @@ concurrency:
 permissions: {}
 
 jobs:
-  update-lockfile:
-    if: github.actor == 'dependabot[bot]'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: audit
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ github.head_ref }}
-      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
-      - run: uv lock
-      - name: Commit updated lockfile
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if git diff --quiet uv.lock; then
-            echo "No lockfile changes"
-            exit 0
-          fi
-          CONTENT=$(base64 -w0 uv.lock)
-          HEAD_OID=$(git rev-parse HEAD)
-          gh api graphql -f query='
-            mutation($input: CreateCommitOnBranchInput!) {
-              createCommitOnBranch(input: $input) {
-                commit { url }
-              }
-            }
-          ' -f "input[branchRef][repositoryNameWithOwner]=${{ github.repository }}" \
-            -f "input[branchRef][branchName]=${{ github.head_ref }}" \
-            -f "input[expectedHeadOid]=${HEAD_OID}" \
-            -f "input[message][headline]=deps: update uv.lock" \
-            -f "input[fileChanges][additions][0][path]=uv.lock" \
-            -f "input[fileChanges][additions][0][contents]=${CONTENT}"
-
   test:
-    needs: [update-lockfile]
-    if: ${{ !cancelled() && needs.update-lockfile.result != 'failure' }}
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -69,7 +29,6 @@ jobs:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.actor == 'dependabot[bot]' && github.head_ref || '' }}
           fetch-depth: 0
       - uses: ./.github/actions/setup-uv
         with:
@@ -81,8 +40,6 @@ jobs:
         run: uv run diff-cover coverage.xml --fail-under=90 --compare-branch=origin/${{ github.base_ref }}
 
   lint:
-    needs: [update-lockfile]
-    if: ${{ !cancelled() && needs.update-lockfile.result != 'failure' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -92,8 +49,6 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ github.actor == 'dependabot[bot]' && github.head_ref || '' }}
       - uses: ./.github/actions/setup-uv
       - name: Ruff check
         run: uv run ruff check .
@@ -101,8 +56,6 @@ jobs:
         run: uv run ruff format --check .
 
   typecheck:
-    needs: [update-lockfile]
-    if: ${{ !cancelled() && needs.update-lockfile.result != 'failure' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -112,11 +65,32 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ github.actor == 'dependabot[bot]' && github.head_ref || '' }}
       - uses: ./.github/actions/setup-uv
       - name: Mypy
         run: uv run mypy src/nexus_mcp
+
+  lockfile:
+    name: lockfile
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      - name: Check uv.lock is in sync with pyproject.toml
+        run: |
+          if ! uv lock --check; then
+            echo "::error title=uv.lock is out of sync::uv.lock does not match pyproject.toml."
+            echo "To fix: run 'uv lock' locally, then commit and push the updated uv.lock to this branch."
+            echo "Dependabot's GITHUB_TOKEN cannot trigger fresh required checks, so CI will not"
+            echo "auto-correct this - a maintainer must push the regenerated uv.lock."
+            exit 1
+          fi
 
   dependency-review:
     name: Dependency Review


### PR DESCRIPTION
## Summary

Removes the Dependabot-only `update-lockfile` CI job that regenerated `uv.lock` and committed it back to the PR branch via `gh api graphql createCommitOnBranch` using `GITHUB_TOKEN`. Because `GITHUB_TOKEN` writes do not trigger fresh workflow runs, that auto-commit became the new PR head with missing/stale required checks — a green-looking run whose resulting head could not satisfy `Protect main`.

The fix is **detect-drift-and-fail-loud** (issue Option A):

- **Delete** the `update-lockfile` job and the `needs:`/`if:` gating plus the Dependabot-only checkout `ref:` overrides it required on `test`, `lint`, `typecheck`.
- A stale `uv.lock` now fails directly on the **real PR head** via `uv sync --locked` in `.github/actions/setup-uv` — which the required checks (`test`, `lint`, `typecheck`) already run — so the `Protect main` ruleset blocks the merge with no ambiguity.
- **Add** a lightweight, clearly-named `lockfile` job that runs `uv lock --check` and, on drift, prints exact maintainer instructions (run `uv lock`, then commit and push `uv.lock`) and exits 1.

No auto-commit path remains. The shared `setup-uv` composite is intentionally **not** modified (it is also consumed by `release.yml`). No new credentials, app, or doc/operational changes — maintainer guidance lives in the CI failure message only.

## Test Plan

Automated (done locally on the branch):
- [x] `actionlint .github/workflows/ci.yml` — clean
- [x] `uv lock --check` — lockfile in sync (the new job passes on a clean tree)
- [x] Unit + e2e suite — 1174 passed

Live-ruleset verification (maintainer, on this PR — the acceptance gate that cannot be inferred from syntax):
- [ ] This PR's `test (ubuntu-latest, 3.13)`, `lint`, `typecheck`, `dependency-safety / gate`, and the new `lockfile` check all run and pass (lockfile is in sync).
- [ ] On a throwaway branch, introduce intentional drift (edit `pyproject.toml` without running `uv lock`) and open a draft PR; confirm `lockfile` fails with the maintainer-instruction annotation and `test`/`lint`/`typecheck` fail at `uv sync --locked`.
- [ ] Confirm the drift PR shows merge **blocked** by `Protect main` (`gh pr checks` reports `fail`, not `skipping`/`pending`).
- [ ] Confirm no `deps: update uv.lock` / bot auto-commit appears on the drift PR head.

> Note: a human stale-lockfile PR is equivalent to a Dependabot one because this change deletes all actor-specific behavior — drift handling is now identical for every author.

Fixes #188.
