### PR TITLE
ci: bump shared-workflows refs to v3.0.2 and add fork-PR safety gate

### DIFF
--- a/.github/workflows/dependency-safety-non-bot-gate.yml
+++ b/.github/workflows/dependency-safety-non-bot-gate.yml
@@ -1,0 +1,45 @@
+name: Dependency Safety Non-Bot Gate
+
+# Status-only gate for non-Dependabot pull requests.
+#
+# External fork PRs get a read-only GITHUB_TOKEN under `pull_request`, so the
+# reusable dependency-safety scanner cannot write the required
+# `dependency-safety / gate` commit status and the PR is wedged by the ruleset.
+# This workflow runs under `pull_request_target` (base-branch privileges) and
+# posts ONLY that required status. It deliberately performs NO checkout, NO
+# dependency install, NO build/test, and uses NO third-party actions and NO
+# PR-authored file - the only shell executed is the inline `gh api` call below.
+# That no-PR-code-execution property is what makes the privileged trigger safe.
+
+on:
+  pull_request_target: # zizmor: ignore[dangerous-triggers] status-only path; never checks out or runs PR code
+    types: [opened, synchronize, reopened]
+    branches: [main]
+
+permissions: {}
+
+concurrency:
+  group: dep-safety-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  gate:
+    # Dependabot PRs are handled by the real reusable scanner in
+    # dependency-safety.yml; every other PR gets this status-only gate.
+    # `pull_request.user.login` is the spoofing-resistant actor field.
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+    steps:
+      - name: Post dependency-safety gate status
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          gh api "repos/${GH_REPO}/statuses/${HEAD_SHA}" \
+            -f state=success \
+            -f context="dependency-safety / gate" \
+            -f description="Non-bot PR: no dependency cooldown scan required" \
+            -f target_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"

--- a/.github/workflows/dependency-safety.yml
+++ b/.github/workflows/dependency-safety.yml
@@ -16,6 +16,11 @@ concurrency:
 
 jobs:
   safety:
-    uses: j7an/shared-workflows/.github/workflows/dependency-safety.yml@522610f12d08a8fe358569d6c533c21af6ac8ec0 # v3.0.1
+    # Real dependency-safety scan runs for Dependabot only; every other PR
+    # (human fork, same-repo branch, other bot) gets the status-only gate in
+    # dependency-safety-non-bot-gate.yml. `pull_request.user.login` is the
+    # spoofing-resistant actor field.
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    uses: j7an/shared-workflows/.github/workflows/dependency-safety.yml@29bcd576f856e85042ab699dce66523711a44b48 # v3.0.2
     with:
       auto_merge: true

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   tag:
-    uses: j7an/shared-workflows/.github/workflows/tag-release.yml@522610f12d08a8fe358569d6c533c21af6ac8ec0 # v3.0.1
+    uses: j7an/shared-workflows/.github/workflows/tag-release.yml@29bcd576f856e85042ab699dce66523711a44b48 # v3.0.2
     with:
       bump: ${{ inputs.bump }}
       tag-prefix: "v"


### PR DESCRIPTION
Bumps every `j7an/shared-workflows` reference to v3.0.2
(`29bcd576f856e85042ab699dce66523711a44b48`), gates the real reusable
dependency-safety scan to Dependabot, and adds a status-only
`pull_request_target` companion that posts the required
`dependency-safety / gate` status for non-Dependabot (including fork) PRs.

## Why

The `Protect main` ruleset requires the `dependency-safety / gate` status.
External fork PRs get a read-only `GITHUB_TOKEN` under `pull_request`, so the
reusable scanner cannot write that status and the PR is wedged. v3.0.2 adds the
fork-PR read-only-token handling (j7an/shared-workflows#80), and the new
companion runs under `pull_request_target` (base-branch privileges, no checkout,
no PR code) to post the required status for every non-Dependabot PR.

## Changes

- `dependency-safety.yml`: bump ref to v3.0.2; gate the real scan to
  `dependabot[bot]` only.
- `tag-release.yml`: bump ref to v3.0.2.
- `dependency-safety-non-bot-gate.yml` (new): status-only `pull_request_target`
  gate for non-Dependabot PRs; `permissions: {}` top-level, job-scoped
  `statuses: write`, no checkout/install/third-party actions/PR code.

## Landing note (one-time bootstrap)

This PR cannot satisfy its own new `dependency-safety / gate`:
`pull_request_target` evaluates the **base-branch** workflow file, and the
companion does not exist on `main` until this PR merges; meanwhile the real
scan is now Dependabot-gated, so it is skipped for this human-authored PR.
Because the `Protect main` ruleset has `current_user_can_bypass: never`, the
gate must be posted once manually against the final head SHA after all other
required checks (`lint`, `typecheck`, `test (ubuntu-latest, 3.13)`) are green,
then squash-merge.

Fixes #213.
