### PR TITLE
ci(deps): bump shared-workflows callers to v4.0.0 (advisory release-age policy)

### DIFF
--- a/.github/workflows/dependency-safety-non-bot-gate.yml
+++ b/.github/workflows/dependency-safety-non-bot-gate.yml
@@ -41,5 +41,5 @@ jobs:
           gh api "repos/${GH_REPO}/statuses/${HEAD_SHA}" \
             -f state=success \
             -f context="dependency-safety / gate" \
-            -f description="Non-bot PR: no dependency cooldown scan required" \
+            -f description="Non-bot PR: dependency-safety scan not required" \
             -f target_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"

--- a/.github/workflows/dependency-safety.yml
+++ b/.github/workflows/dependency-safety.yml
@@ -21,6 +21,8 @@ jobs:
     # dependency-safety-non-bot-gate.yml. `pull_request.user.login` is the
     # spoofing-resistant actor field.
     if: github.event.pull_request.user.login == 'dependabot[bot]'
-    uses: j7an/shared-workflows/.github/workflows/dependency-safety.yml@29bcd576f856e85042ab699dce66523711a44b48 # v3.0.2
+    uses: j7an/shared-workflows/.github/workflows/dependency-safety.yml@dd7254ccf917f2e8385f209986b6139ac4651b88 # v4.0.0
     with:
       auto_merge: true
+      release_age_policy: advisory
+      minimum_release_age_days: 5

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   tag:
-    uses: j7an/shared-workflows/.github/workflows/tag-release.yml@29bcd576f856e85042ab699dce66523711a44b48 # v3.0.2
+    uses: j7an/shared-workflows/.github/workflows/tag-release.yml@dd7254ccf917f2e8385f209986b6139ac4651b88 # v4.0.0
     with:
       bump: ${{ inputs.bump }}
       tag-prefix: "v"


### PR DESCRIPTION
Bumps both `j7an/shared-workflows` callers from v3.0.2 to v4.0.0 (`dd7254ccf917f2e8385f209986b6139ac4651b88`).

v4.0.0 removed `fail_on_age_violation` and added `release_age_policy` (defaulting to `"off"`), so a plain ref bump would silently drop release-age checking. This sets `release_age_policy: advisory` with `minimum_release_age_days: 5` (matching Dependabot `cooldown.default-days: 5`): the required `dependency-safety / gate` stays green for young security updates, while young updates are still labeled/commented and held back from auto-merge for manual review.

- `dependency-safety.yml`: SHA bump + `release_age_policy: advisory` + `minimum_release_age_days: 5` (`auto_merge: true` unchanged).
- `tag-release.yml`: pure ref bump (no input/secret contract change).
- `dependency-safety-non-bot-gate.yml`: status-description wording refresh only; behavior unchanged.

Mirrors merged reference PR j7an/dep-rank#133. Validated with `actionlint` and `zizmor` (min-severity/confidence medium); v4.0.0 input contract verified against the pinned SHA.
