### PR TITLE
ci: adopt shared-workflows v4.2.2

### DIFF
--- a/.github/workflows/dependency-safety-non-bot-gate.yml
+++ b/.github/workflows/dependency-safety-non-bot-gate.yml
@@ -15,4 +15,4 @@ jobs:
   gate:
     permissions:
       statuses: write
-    uses: j7an/shared-workflows/.github/workflows/dependency-safety-non-bot-gate.yml@5997f2092ef3fea11a5bcdca8ec81382bcc30eba # v4.1.0
+    uses: j7an/shared-workflows/.github/workflows/dependency-safety-non-bot-gate.yml@dc9105acf09a4ad43bad2e4a86f4c65f553fe3c0 # v4.2.2

--- a/.github/workflows/dependency-safety.yml
+++ b/.github/workflows/dependency-safety.yml
@@ -21,7 +21,7 @@ jobs:
     # dependency-safety-non-bot-gate.yml. `pull_request.user.login` is the
     # spoofing-resistant actor field.
     if: github.event.pull_request.user.login == 'dependabot[bot]'
-    uses: j7an/shared-workflows/.github/workflows/dependency-safety.yml@5997f2092ef3fea11a5bcdca8ec81382bcc30eba # v4.1.0
+    uses: j7an/shared-workflows/.github/workflows/dependency-safety.yml@dc9105acf09a4ad43bad2e4a86f4c65f553fe3c0 # v4.2.2
     with:
       auto_merge: true
       release_age_policy: advisory

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -16,6 +16,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: j7an/shared-workflows/.github/workflows/pre-commit-autoupdate.yml@5997f2092ef3fea11a5bcdca8ec81382bcc30eba # v4.1.0
+    uses: j7an/shared-workflows/.github/workflows/pre-commit-autoupdate.yml@dc9105acf09a4ad43bad2e4a86f4c65f553fe3c0 # v4.2.2
     secrets:
       RELEASE_BOT_PRIVATE_KEY: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,14 @@ concurrency:
   group: pypi-release-${{ github.ref_name }}
   cancel-in-progress: false
 
+env:
+  PACKAGE_NAME: nexus-mcp
+  PACKAGE_DIR: .
+  VERIFY_PYTHON: "3.13"
+  VERIFY_COMMAND: nexus-mcp --version
+  DRAFT_RELEASE: "true"
+  ATTACH_ASSETS: "true"
+
 jobs:
   test:
     name: Lint, typecheck, and test
@@ -36,26 +44,229 @@ jobs:
       - name: Run tests
         run: uv run pytest -m "not integration"
 
-  publish-pypi:
-    name: Publish to PyPI
+  build:
+    name: Build distributions
     needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - name: Checkout at tag
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.ref_name }}
+          fetch-depth: 0
+      - name: Verify tag is ancestor of main
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          TAG_SHA=$(git rev-list -n1 "$TAG")
+          git fetch origin main
+          if ! git merge-base --is-ancestor "$TAG_SHA" origin/main; then
+            echo "::error::Tag ${TAG} (${TAG_SHA}) is not an ancestor of origin/main"
+            exit 1
+          fi
+      - uses: ./.github/actions/setup-uv
+      - name: Build wheel and sdist
+        working-directory: ${{ env.PACKAGE_DIR }}
+        run: uv build
+      - name: Verify built version matches tag
+        env:
+          TAG: ${{ github.ref_name }}
+        run: bash scripts/derive-published-version.sh "${PACKAGE_DIR}/dist" "$TAG"
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pypi-dist
+          path: ${{ env.PACKAGE_DIR }}/dist/
+          if-no-files-found: error
+          retention-days: 7
+
+  publish-testpypi:
+    name: Publish to TestPyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/nexus-mcp
     permissions:
-      contents: write
       id-token: write
       attestations: write
-    uses: j7an/shared-workflows/.github/workflows/publish-pypi.yml@dc9105acf09a4ad43bad2e4a86f4c65f553fe3c0 # v4.2.2
-    with:
-      tag: ${{ github.ref_name }}
-      package-dir: .
-      testpypi-package: nexus-mcp
-      verify-python: "3.13"
-      draft-release: true
-      attach-assets: true
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - name: Download dist artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: pypi-dist
+          path: dist/
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          packages-dir: dist/
+          skip-existing: false
+
+  verify-testpypi:
+    name: Verify TestPyPI install
+    needs: publish-testpypi
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - name: Set up uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      - name: Verify install from TestPyPI
+        env:
+          PACKAGE_NAME: ${{ env.PACKAGE_NAME }}
+          VERIFY_PYTHON: ${{ env.VERIFY_PYTHON }}
+          VERIFY_COMMAND: ${{ env.VERIFY_COMMAND }}
+          VERSION_TAG: ${{ github.ref_name }}
+        run: |
+          VERSION="${VERSION_TAG##*/}"
+          VERSION="${VERSION#v}"
+          if ! printf '%s' "$VERIFY_PYTHON" | grep -qE '^[0-9]+(\.[0-9]+){1,2}$'; then
+            echo "::error::VERIFY_PYTHON must be a version like 3.13 or 3.13.2, got '$VERIFY_PYTHON'"
+            exit 1
+          fi
+          if ! printf '%s' "$PACKAGE_NAME" | grep -qE '^[A-Za-z0-9][A-Za-z0-9._-]*$'; then
+            echo "::error::PACKAGE_NAME contains characters that cannot be safely written to pyproject.toml: '$PACKAGE_NAME'"
+            exit 1
+          fi
+          echo "Verifying TestPyPI install of ${PACKAGE_NAME}==${VERSION} with Python ${VERIFY_PYTHON}"
+
+          INSTALLED=false
+          ATTEMPT=0
+          for SLEEP_SECONDS in 30 60 90 120 150; do
+            ATTEMPT=$((ATTEMPT + 1))
+            echo "Attempt ${ATTEMPT}/5: sleeping ${SLEEP_SECONDS}s before install..."
+            sleep "$SLEEP_SECONDS"
+            rm -rf .verify
+            mkdir -p .verify
+            cat > .verify/pyproject.toml <<EOF
+          [project]
+          name = "testpypi-verify"
+          version = "0.0.0"
+          requires-python = ">=${VERIFY_PYTHON}"
+          dependencies = [
+            "${PACKAGE_NAME}==${VERSION}",
+          ]
+
+          [tool.uv.sources]
+          "${PACKAGE_NAME}" = { index = "testpypi" }
+
+          [[tool.uv.index]]
+          name = "testpypi"
+          url = "https://test.pypi.org/simple/"
+          explicit = true
+          EOF
+            if (cd .verify && uv sync --python "$VERIFY_PYTHON" --refresh-package "$PACKAGE_NAME"); then
+              INSTALLED=true
+              break
+            fi
+            echo "Attempt ${ATTEMPT} failed; retrying."
+          done
+
+          if [ "$INSTALLED" != "true" ]; then
+            echo "::error::TestPyPI install verification failed after 5 attempts"
+            exit 1
+          fi
+
+          if [ -n "${VERIFY_COMMAND:-}" ]; then
+            if ! VERIFY_OUTPUT=$(cd .verify && uv run --no-sync bash -euo pipefail -c "$VERIFY_COMMAND" 2>&1); then
+              printf '%s\n' "$VERIFY_OUTPUT"
+              echo "::error::Verification command failed"
+              exit 1
+            fi
+            printf '%s\n' "$VERIFY_OUTPUT"
+            case "$VERIFY_OUTPUT" in
+              *"$VERSION"*) ;;
+              *)
+                echo "::error::Verification command output did not contain version '${VERSION}'"
+                exit 1
+                ;;
+            esac
+          fi
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: verify-testpypi
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/nexus-mcp
+    permissions:
+      id-token: write
+      attestations: write
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - name: Download dist artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: pypi-dist
+          path: dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          packages-dir: dist/
+
+  github-release:
+    name: Create GitHub Release
+    needs: publish-pypi
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - name: Checkout at tag
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.ref_name }}
+      - name: Download dist artifact
+        if: env.ATTACH_ASSETS == 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: pypi-dist
+          path: dist/
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+          VERSION_TAG: ${{ github.ref_name }}
+        run: |
+          VERSION="${VERSION_TAG##*/}"
+          VERSION="${VERSION#v}"
+          IS_PRERELEASE=$(bash scripts/classify-prerelease.sh "$VERSION")
+          ARGS=( "$TAG" --generate-notes --title "$TAG" )
+          if [ "$IS_PRERELEASE" = "true" ]; then
+            ARGS+=( --prerelease )
+          fi
+          if [ "$DRAFT_RELEASE" = "true" ]; then
+            ARGS+=( --draft )
+          fi
+          if [ "$ATTACH_ASSETS" = "true" ]; then
+            ARGS+=( dist/*.whl dist/*.tar.gz )
+          fi
+          gh release create "${ARGS[@]}"
 
   publish-mcp-registry:
     name: Publish to MCP Registry
-    needs: publish-pypi
-    if: needs.publish-pypi.result == 'success'
+    needs: github-release
+    if: needs.github-release.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,13 +12,6 @@ concurrency:
   group: pypi-release-${{ github.ref_name }}
   cancel-in-progress: false
 
-env:
-  PACKAGE_NAME: nexus-mcp
-  PACKAGE_DIR: .
-  VERIFY_COMMAND: nexus-mcp --version
-  DRAFT_RELEASE: "true"
-  ATTACH_ASSETS: "true"
-
 jobs:
   test:
     name: Lint, typecheck, and test
@@ -43,203 +36,25 @@ jobs:
       - name: Run tests
         run: uv run pytest -m "not integration"
 
-  build:
-    name: Build distributions
-    needs: test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: audit
-      - name: Checkout at tag
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: ${{ github.ref_name }}
-          fetch-depth: 0
-      - name: Verify tag is ancestor of main
-        env:
-          TAG: ${{ github.ref_name }}
-        run: |
-          TAG_SHA=$(git rev-list -n1 "$TAG")
-          git fetch origin main
-          if ! git merge-base --is-ancestor "$TAG_SHA" origin/main; then
-            echo "::error::Tag ${TAG} (${TAG_SHA}) is not an ancestor of origin/main"
-            exit 1
-          fi
-      - uses: ./.github/actions/setup-uv
-      - name: Build wheel and sdist
-        working-directory: ${{ env.PACKAGE_DIR }}
-        run: uv build
-      - name: Verify built version matches tag
-        env:
-          TAG: ${{ github.ref_name }}
-        run: bash scripts/derive-published-version.sh "${PACKAGE_DIR}/dist" "$TAG"
-      - name: Upload dist artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: pypi-dist
-          path: ${{ env.PACKAGE_DIR }}/dist/
-          if-no-files-found: error
-          retention-days: 7
-
-  publish-testpypi:
-    name: Publish to TestPyPI
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: testpypi
-      url: https://test.pypi.org/p/nexus-mcp
-    permissions:
-      id-token: write
-      attestations: write
-    steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: audit
-      - name: Download dist artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: pypi-dist
-          path: dist/
-      - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
-        with:
-          repository-url: https://test.pypi.org/legacy/
-          packages-dir: dist/
-          skip-existing: false
-
-  verify-testpypi:
-    name: Verify TestPyPI install
-    needs: publish-testpypi
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: audit
-      - name: Set up uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-      - name: Verify install from TestPyPI
-        env:
-          PACKAGE_NAME: ${{ env.PACKAGE_NAME }}
-          VERIFY_COMMAND: ${{ env.VERIFY_COMMAND }}
-          VERSION_TAG: ${{ github.ref_name }}
-        run: |
-          VERSION="${VERSION_TAG##*/}"
-          VERSION="${VERSION#v}"
-          echo "Verifying TestPyPI install of ${PACKAGE_NAME}==${VERSION}"
-          INSTALLED=false
-          ATTEMPT=0
-          for SLEEP_SECONDS in 30 60 90 120 150; do
-            ATTEMPT=$((ATTEMPT + 1))
-            echo "Attempt ${ATTEMPT}/5: sleeping ${SLEEP_SECONDS}s before install..."
-            sleep "$SLEEP_SECONDS"
-            rm -rf .verify
-            uv venv .verify
-            . .verify/bin/activate
-            if uv pip install \
-              --index-url https://test.pypi.org/simple/ \
-              --extra-index-url https://pypi.org/simple/ \
-              "${PACKAGE_NAME}==${VERSION}"; then
-              INSTALLED=true
-              break
-            fi
-            echo "Attempt ${ATTEMPT} failed; retrying."
-          done
-          if [ "$INSTALLED" != "true" ]; then
-            echo "::error::TestPyPI install verification failed after 5 attempts"
-            exit 1
-          fi
-          if [ -n "${VERIFY_COMMAND:-}" ]; then
-            if ! VERIFY_OUTPUT=$(bash -euo pipefail -c "$VERIFY_COMMAND" 2>&1); then
-              printf '%s\n' "$VERIFY_OUTPUT"
-              echo "::error::Verification command failed"
-              exit 1
-            fi
-            printf '%s\n' "$VERIFY_OUTPUT"
-            case "$VERIFY_OUTPUT" in
-              *"$VERSION"*) ;;
-              *)
-                echo "::error::Verification command output did not contain version '${VERSION}'"
-                exit 1
-                ;;
-            esac
-          fi
-
   publish-pypi:
     name: Publish to PyPI
-    needs: verify-testpypi
-    runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/p/nexus-mcp
-    permissions:
-      id-token: write
-      attestations: write
-    steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: audit
-      - name: Download dist artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: pypi-dist
-          path: dist/
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
-        with:
-          packages-dir: dist/
-
-  github-release:
-    name: Create GitHub Release
-    needs: publish-pypi
-    runs-on: ubuntu-latest
+    needs: test
     permissions:
       contents: write
-    steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: audit
-      - name: Checkout at tag
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: ${{ github.ref_name }}
-      - name: Download dist artifact
-        if: env.ATTACH_ASSETS == 'true'
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: pypi-dist
-          path: dist/
-      - name: Create GitHub Release
-        env:
-          GH_TOKEN: ${{ github.token }}
-          TAG: ${{ github.ref_name }}
-          VERSION_TAG: ${{ github.ref_name }}
-        run: |
-          VERSION="${VERSION_TAG##*/}"
-          VERSION="${VERSION#v}"
-          IS_PRERELEASE=$(bash scripts/classify-prerelease.sh "$VERSION")
-          ARGS=( "$TAG" --generate-notes --title "$TAG" )
-          if [ "$IS_PRERELEASE" = "true" ]; then
-            ARGS+=( --prerelease )
-          fi
-          if [ "$DRAFT_RELEASE" = "true" ]; then
-            ARGS+=( --draft )
-          fi
-          if [ "$ATTACH_ASSETS" = "true" ]; then
-            ARGS+=( dist/*.whl dist/*.tar.gz )
-          fi
-          gh release create "${ARGS[@]}"
+      id-token: write
+      attestations: write
+    uses: j7an/shared-workflows/.github/workflows/publish-pypi.yml@dc9105acf09a4ad43bad2e4a86f4c65f553fe3c0 # v4.2.2
+    with:
+      tag: ${{ github.ref_name }}
+      package-dir: .
+      testpypi-package: nexus-mcp
+      verify-python: "3.13"
+      draft-release: true
+      attach-assets: true
 
   publish-mcp-registry:
     name: Publish to MCP Registry
-    needs: [build, publish-pypi]
+    needs: publish-pypi
     if: needs.publish-pypi.result == 'success'
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,4 +20,4 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: j7an/shared-workflows/.github/workflows/security-scan.yml@5997f2092ef3fea11a5bcdca8ec81382bcc30eba # v4.1.0
+    uses: j7an/shared-workflows/.github/workflows/security-scan.yml@dc9105acf09a4ad43bad2e4a86f4c65f553fe3c0 # v4.2.2

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   tag:
-    uses: j7an/shared-workflows/.github/workflows/tag-release.yml@5997f2092ef3fea11a5bcdca8ec81382bcc30eba # v4.1.0
+    uses: j7an/shared-workflows/.github/workflows/tag-release.yml@dc9105acf09a4ad43bad2e4a86f4c65f553fe3c0 # v4.2.2
     with:
       bump: ${{ inputs.bump }}
       tag-prefix: "v"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,21 @@ uv run pre-commit run --all-files
 - Do not use `git add -A` or `git add .`; stage explicit paths.
 - Ask before adding new dependencies or making destructive changes.
 
+## Release Workflow Guidance
+
+- Keep PyPI and TestPyPI Trusted Publishing jobs caller-owned in
+  `.github/workflows/release.yml`. Do not replace them with
+  `j7an/shared-workflows/.github/workflows/publish-pypi.yml`; PyPI does not
+  authorize cross-repo reusable workflows as trusted-publisher workflows.
+- When porting fixes from `shared-workflows`, use the caller-owned PyPI
+  Trusted Publishing template and preserve Nexus-specific safeguards:
+  `VERIFY_PYTHON: "3.13"`, `VERIFY_COMMAND: nexus-mcp --version`,
+  `scripts/derive-published-version.sh` before upload, TestPyPI and PyPI
+  environment URLs, and MCP Registry publishing gated on GitHub release success.
+- Pin reusable `shared-workflows` callers to immutable commit SHAs with a
+  version comment, but keep PyPI publishing inline unless PyPI explicitly
+  supports cross-repo reusable workflows for Trusted Publishing.
+
 ## Python Code Style
 
 ### Modern Syntax (Python 3.13+)


### PR DESCRIPTION
## Summary

- update all active `j7an/shared-workflows` reusable workflow callers to the `v4.2.2` commit pin
- keep PyPI/TestPyPI Trusted Publishing caller-owned in `release.yml`, while porting the v4.2.2 TestPyPI verification fixes inline
- set `VERIFY_PYTHON: "3.13"` explicitly in this repo, preserve the `nexus-mcp --version` smoke test, and keep the pre-upload version guard
- document the PyPI Trusted Publishing constraint in `AGENTS.md` so future shared-workflows updates do not move PyPI publishing into a reusable workflow

Refs j7an/shared-workflows#106.

## Verification

- `actionlint .github/workflows/release.yml .github/workflows/dependency-safety-non-bot-gate.yml .github/workflows/dependency-safety.yml .github/workflows/pre-commit-autoupdate.yml .github/workflows/security.yml .github/workflows/tag-release.yml`
- `uv run pre-commit run check-yaml --files AGENTS.md .github/workflows/release.yml .github/workflows/dependency-safety-non-bot-gate.yml .github/workflows/dependency-safety.yml .github/workflows/pre-commit-autoupdate.yml .github/workflows/security.yml .github/workflows/tag-release.yml`
- `git diff --check`
- `uv run pytest -m "not integration"`: 1174 passed, 15 deselected
