### PR TITLE
ci: disable uv cache in TestPyPI verifier

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,6 +124,8 @@ jobs:
           egress-policy: audit
       - name: Set up uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
       - name: Verify install from TestPyPI
         env:
           PACKAGE_NAME: ${{ env.PACKAGE_NAME }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,11 @@ uv run pre-commit run --all-files
   `VERIFY_PYTHON: "3.13"`, `VERIFY_COMMAND: nexus-mcp --version`,
   `scripts/derive-published-version.sh` before upload, TestPyPI and PyPI
   environment URLs, and MCP Registry publishing gated on GitHub release success.
+- Keep `setup-uv` caching disabled in the TestPyPI verification job while it
+  intentionally skips checkout and creates the throwaway `.verify` project
+  later. If caching is re-enabled, the job must first provide real dependency
+  files for `setup-uv` to hash so release runs do not emit empty-workdir or
+  cache-dependency warnings.
 - Pin reusable `shared-workflows` callers to immutable commit SHAs with a
   version comment, but keep PyPI publishing inline unless PyPI explicitly
   supports cross-repo reusable workflows for Trusted Publishing.

--- a/tests/unit/test_release_workflow.py
+++ b/tests/unit/test_release_workflow.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
+
+
+def _workflow_text() -> str:
+    return RELEASE_WORKFLOW.read_text(encoding="utf-8")
+
+
+def test_testpypi_verifier_disables_setup_uv_cache() -> None:
+    workflow = _workflow_text()
+
+    job_start = workflow.index("  verify-testpypi:")
+    next_job = workflow.index("\n  publish-pypi:", job_start)
+    verify_job = workflow[job_start:next_job]
+
+    setup_start = verify_job.index("      - name: Set up uv")
+    next_step = verify_job.index("\n      - name:", setup_start + 1)
+    setup_step = verify_job[setup_start:next_step]
+
+    assert "uses: astral-sh/setup-uv@" in setup_step
+    assert "with:" in setup_step
+    assert "enable-cache: false" in setup_step


### PR DESCRIPTION
## Summary

- Disable `setup-uv` caching in the TestPyPI verification job so the intentionally empty no-checkout workspace does not emit cache-dependency or empty-workdir warnings.
- Add a focused workflow regression test for the verifier's `setup-uv` step.
- Document the release verifier guardrail in `AGENTS.md`.

## Verification

- `rtk env UV_CACHE_DIR=.uv-cache uv run pytest tests/unit/test_release_workflow.py::test_testpypi_verifier_disables_setup_uv_cache -q`
- `rtk actionlint .github/workflows/release.yml`
- `rtk env UV_CACHE_DIR=.uv-cache uv run pre-commit run --files AGENTS.md .github/workflows/release.yml tests/unit/test_release_workflow.py`
- `rtk git diff --check`
