### PR TITLE
ci: adopt shared-workflows v4.2.3

### DIFF
--- a/.github/workflows/dependency-safety-non-bot-gate.yml
+++ b/.github/workflows/dependency-safety-non-bot-gate.yml
@@ -15,4 +15,4 @@ jobs:
   gate:
     permissions:
       statuses: write
-    uses: j7an/shared-workflows/.github/workflows/dependency-safety-non-bot-gate.yml@dc9105acf09a4ad43bad2e4a86f4c65f553fe3c0 # v4.2.2
+    uses: j7an/shared-workflows/.github/workflows/dependency-safety-non-bot-gate.yml@e22b38d70bf615d2e250718d430a5a4688fee158 # v4.2.3

--- a/.github/workflows/dependency-safety.yml
+++ b/.github/workflows/dependency-safety.yml
@@ -21,7 +21,7 @@ jobs:
     # dependency-safety-non-bot-gate.yml. `pull_request.user.login` is the
     # spoofing-resistant actor field.
     if: github.event.pull_request.user.login == 'dependabot[bot]'
-    uses: j7an/shared-workflows/.github/workflows/dependency-safety.yml@dc9105acf09a4ad43bad2e4a86f4c65f553fe3c0 # v4.2.2
+    uses: j7an/shared-workflows/.github/workflows/dependency-safety.yml@e22b38d70bf615d2e250718d430a5a4688fee158 # v4.2.3
     with:
       auto_merge: true
       release_age_policy: advisory

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -16,6 +16,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: j7an/shared-workflows/.github/workflows/pre-commit-autoupdate.yml@dc9105acf09a4ad43bad2e4a86f4c65f553fe3c0 # v4.2.2
+    uses: j7an/shared-workflows/.github/workflows/pre-commit-autoupdate.yml@e22b38d70bf615d2e250718d430a5a4688fee158 # v4.2.3
     secrets:
       RELEASE_BOT_PRIVATE_KEY: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,4 +20,4 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: j7an/shared-workflows/.github/workflows/security-scan.yml@dc9105acf09a4ad43bad2e4a86f4c65f553fe3c0 # v4.2.2
+    uses: j7an/shared-workflows/.github/workflows/security-scan.yml@e22b38d70bf615d2e250718d430a5a4688fee158 # v4.2.3

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   tag:
-    uses: j7an/shared-workflows/.github/workflows/tag-release.yml@dc9105acf09a4ad43bad2e4a86f4c65f553fe3c0 # v4.2.2
+    uses: j7an/shared-workflows/.github/workflows/tag-release.yml@e22b38d70bf615d2e250718d430a5a4688fee158 # v4.2.3
     with:
       bump: ${{ inputs.bump }}
       tag-prefix: "v"


### PR DESCRIPTION
## Summary

- update all five reusable `shared-workflows` callers to the immutable v4.2.3 commit
- pick up the upstream CodeQL, TruffleHog, setup-uv, and harden-runner refreshes
- preserve Nexus-specific caller inputs and inline PyPI/TestPyPI Trusted Publishing jobs

## Verification

- `actionlint` on all five changed workflow files
- `uv run pre-commit run --all-files`
- `uv run pytest -m 'not integration'` (1,175 passed, 15 deselected)

The pre-change full suite also ran: 1,178 passed and 11 skipped; the sole failure was the real OpenCode integration test receiving an unrelated `401 Unauthorized` response from `ollama.com`.
